### PR TITLE
fix: ship auto-memory-hook.mjs on init; clarify destructive-ops gate message

### DIFF
--- a/.claude/helpers/handlers/gates-handler.cjs
+++ b/.claude/helpers/handlers/gates-handler.cjs
@@ -10,7 +10,7 @@
  * and valid it replaces the built-in tables.
  *
  * Gates enforced at runtime:
- *   pre-bash  → destructive-ops  (require-confirmation → block)
+ *   pre-bash  → destructive-ops  (hard block; no confirm-and-proceed path exists)
  *   pre-write → secrets          (block)
  */
 
@@ -234,7 +234,7 @@ function checkDestructive(command, patterns) {
       return {
         triggered: true,
         matched: match[0],
-        reason: `Destructive operation detected: "${match[0]}". Confirm this is intentional and document a rollback plan before proceeding.`,
+        reason: `Destructive operation blocked: "${match[0]}". This hook always blocks (Claude Code's PreToolUse protocol has no confirm-and-proceed path) — there is no way to run this exact command after confirming. If it's genuinely intended, use a non-destructive equivalent instead (e.g. move the target aside, or scope the operation more narrowly).`,
       };
     }
   }

--- a/packages/@monomind/cli/.claude/helpers/handlers/gates-handler.cjs
+++ b/packages/@monomind/cli/.claude/helpers/handlers/gates-handler.cjs
@@ -6,7 +6,7 @@
  * @monomind/guidance package it mirrored has been removed.
  *
  * Gates enforced at runtime:
- *   pre-bash  → destructive-ops  (require-confirmation → block)
+ *   pre-bash  → destructive-ops  (hard block; no confirm-and-proceed path exists)
  *   pre-write → secrets          (block)
  */
 
@@ -60,7 +60,7 @@ function checkDestructive(command) {
       return {
         triggered: true,
         matched: match[0],
-        reason: `Destructive operation detected: "${match[0]}". Confirm this is intentional and document a rollback plan before proceeding.`,
+        reason: `Destructive operation blocked: "${match[0]}". This hook always blocks (Claude Code's PreToolUse protocol has no confirm-and-proceed path) — there is no way to run this exact command after confirming. If it's genuinely intended, use a non-destructive equivalent instead (e.g. move the target aside, or scope the operation more narrowly).`,
       };
     }
   }

--- a/packages/@monomind/cli/__tests__/init-e2e.test.ts
+++ b/packages/@monomind/cli/__tests__/init-e2e.test.ts
@@ -111,6 +111,20 @@ describe('Init Command E2E (real fs)', () => {
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'agents'))).toBe(true);
   });
 
+  it('should always write auto-memory-hook.mjs even when it is absent from the source helpers dir', async () => {
+    // Regression test: writeHelpers() used to return early as soon as it copied
+    // *any* file from the source .claude/helpers dir, skipping the fallback
+    // generator for files missing from that source dir specifically. Since the
+    // packaged source helpers dir has never actually shipped auto-memory-hook.mjs,
+    // every real init wired SessionStart/SessionEnd/Stop hooks to a file that
+    // was never written, crashing with MODULE_NOT_FOUND on every session end.
+    const result = await initCommand.action!(ctx);
+
+    expect(result.success).toBe(true);
+    const hookPath = path.join(tmpDir, '.claude', 'helpers', 'auto-memory-hook.mjs');
+    expect(fs.existsSync(hookPath)).toBe(true);
+  });
+
   it('should reinitialize with force flag', async () => {
     // First init
     const first = await initCommand.action!(ctx);

--- a/packages/@monomind/cli/src/init/executor.ts
+++ b/packages/@monomind/cli/src/init/executor.ts
@@ -1320,8 +1320,6 @@ async function writeHelpers(
 
   // Try to copy existing helpers from source first (recursive — includes utils/ and handlers/)
   if (sourceHelpersDir && fs.existsSync(sourceHelpersDir)) {
-    let copiedCount = 0;
-
     const copyRecursive = (srcDir: string, destDir: string, relBase: string) => {
       fs.mkdirSync(destDir, { recursive: true });
       for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
@@ -1341,7 +1339,6 @@ async function writeHelpers(
               fs.chmodSync(destPath, '755');
             }
             result.created.files.push(`.claude/helpers/${relPath}`);
-            copiedCount++;
           } else {
             result.skipped.push(`.claude/helpers/${relPath}`);
           }
@@ -1350,13 +1347,13 @@ async function writeHelpers(
     };
 
     copyRecursive(sourceHelpersDir, helpersDir, '');
-
-    if (copiedCount > 0) {
-      return; // Skip generating if we copied from source
-    }
   }
 
-  // Fall back to generating helpers if source not available
+  // Always run the fallback generator too — it only fills in files still missing
+  // after the source copy above (it no-ops on anything the copy already wrote).
+  // Without this, a source dir that's present but incomplete (e.g. missing
+  // auto-memory-hook.mjs) silently ships a project wired to hooks that reference
+  // a file that was never installed.
   const helpers: Record<string, string> = {
     'pre-commit': generatePreCommitHook(),
     'post-commit': generatePostCommitHook(),


### PR DESCRIPTION
## Summary
- `writeHelpers()` returned early as soon as it copied *any* file from the packaged `.claude/helpers` source dir, so it never fell back to generating files missing from that source dir specifically. `auto-memory-hook.mjs` has apparently never actually been shipped in the packaged `.claude/helpers` template, yet `init` unconditionally wires `SessionStart`/`SessionEnd`/`Stop` hooks to it — so every fresh `init` crashes with `MODULE_NOT_FOUND` on session end. Now the fallback generator always runs after the source copy and only fills in whatever's still missing (it no-ops on anything the copy already wrote).
- Reworded the destructive-ops gate's blocked-command message in `gates-handler.cjs` (both the repo's own `.claude/helpers` and the packaged `packages/@monomind/cli/.claude/helpers` copy): it previously said "Confirm this is intentional and document a rollback plan before proceeding," implying a confirm-and-proceed path exists. It doesn't — Claude Code's `PreToolUse` hook protocol only supports allow/block, so there is no way to actually get the exact command through after "confirming." The message now says the block is unconditional and suggests a non-destructive equivalent instead.

## Test plan
- [x] Added a regression test in `init-e2e.test.ts` asserting `auto-memory-hook.mjs` exists on disk after `init` — confirmed it fails on unfixed `executor.ts` and passes with the fix.
- [x] `npx vitest run __tests__/init-e2e.test.ts __tests__/monovector/init-state.test.ts __tests__/p1-commands.test.ts` — 60/60 passing.
- [x] `npx tsc --noEmit` shows no new errors from `executor.ts` (two pre-existing, unrelated errors in `hooks-workers.ts` from a missing `@monomind/hooks` build reproduce identically on `main`).
- [x] Manually verified both `gates-handler.cjs` copies still parse and block correctly with the new message.