### PR TITLE
fix: wire real subagent success/failure signal into routing feedback; skip TypeScript check for non-Node projects

### DIFF
--- a/.claude/helpers/handlers/capture-handler.cjs
+++ b/.claude/helpers/handlers/capture-handler.cjs
@@ -41,6 +41,18 @@ function subagentKey(hookInput) {
   return crypto.createHash('md5').update(String(raw)).digest('hex').slice(0, 16);
 }
 
+// Determine subagent success from its result summary — errors/failures/
+// exceptions indicate failure. Shared by the Monograph `success` column and
+// the intelligence.feedback() call below, so both use one definition.
+function deriveSubagentSuccess(summary) {
+  if (!summary) return true;
+  var sumLower = summary.toLowerCase();
+  if (sumLower.includes('error') || sumLower.includes('failed') || sumLower.includes('exception') || sumLower.includes('fatal')) {
+    return false;
+  }
+  return true;
+}
+
 // Delete snap-*.json files older than SNAP_MAX_AGE_MS — orphaned when a
 // SubagentStop never arrived (crash, forced-stop) or was matched to a
 // different snapshot before keyed matching existed.
@@ -345,6 +357,17 @@ async function handleSubagentStop(hookInput) {
     + (session ? ' · sess=' + session : '')
     + (org ? ' · ' + org + '/' + runId : ''));
 
+  // Feed the real per-subagent success/failure signal into the same
+  // intelligence-outcomes.jsonl that session-handler.cjs's SessionEnd
+  // heuristic reads (via outcomesSignal) to veto a commit-based "success".
+  // Without this, that veto path never fires — SubagentStop is the only
+  // remaining event that carries a genuine failure signal, since post-task
+  // (TeammateIdle/TaskCompleted) is dead code (those aren't valid Claude
+  // Code hook events and are stripped from settings.json on init).
+  try {
+    require('../intelligence.cjs').feedback(deriveSubagentSuccess(summary));
+  } catch (e) { /* non-fatal — feedback recording must never block subagent-stop */ }
+
   if (!org && !session) {
     // No active org or session — log to general capture file only
     // P2-26: rotate — was a pure appendFileSync with no cap, unlike
@@ -486,16 +509,7 @@ async function handleSubagentStop(hookInput) {
             tokens_in: totalTin || 0,
             tokens_out: totalTout || 0,
             cost_usd: costUsd || 0,
-            success: (function() {
-              // Determine success from result summary — errors/failures/exceptions indicate failure
-              if (summary) {
-                var sumLower = summary.toLowerCase();
-                if (sumLower.includes('error') || sumLower.includes('failed') || sumLower.includes('exception') || sumLower.includes('fatal')) {
-                  return 0;
-                }
-              }
-              return 1;
-            })(),
+            success: deriveSubagentSuccess(summary) ? 1 : 0,
             duration_ms: snap.ts ? (Date.now() - snap.ts) : 0,
             timestamp: Date.now(),
           });

--- a/packages/@monomind/cli/.claude/helpers/handlers/capture-handler.cjs
+++ b/packages/@monomind/cli/.claude/helpers/handlers/capture-handler.cjs
@@ -41,6 +41,18 @@ function subagentKey(hookInput) {
   return crypto.createHash('md5').update(String(raw)).digest('hex').slice(0, 16);
 }
 
+// Determine subagent success from its result summary — errors/failures/
+// exceptions indicate failure. Shared by the Monograph `success` column and
+// the intelligence.feedback() call below, so both use one definition.
+function deriveSubagentSuccess(summary) {
+  if (!summary) return true;
+  var sumLower = summary.toLowerCase();
+  if (sumLower.includes('error') || sumLower.includes('failed') || sumLower.includes('exception') || sumLower.includes('fatal')) {
+    return false;
+  }
+  return true;
+}
+
 // Delete snap-*.json files older than SNAP_MAX_AGE_MS — orphaned when a
 // SubagentStop never arrived (crash, forced-stop) or was matched to a
 // different snapshot before keyed matching existed.
@@ -345,6 +357,17 @@ async function handleSubagentStop(hookInput) {
     + (session ? ' · sess=' + session : '')
     + (org ? ' · ' + org + '/' + runId : ''));
 
+  // Feed the real per-subagent success/failure signal into the same
+  // intelligence-outcomes.jsonl that session-handler.cjs's SessionEnd
+  // heuristic reads (via outcomesSignal) to veto a commit-based "success".
+  // Without this, that veto path never fires — SubagentStop is the only
+  // remaining event that carries a genuine failure signal, since post-task
+  // (TeammateIdle/TaskCompleted) is dead code (those aren't valid Claude
+  // Code hook events and are stripped from settings.json on init).
+  try {
+    require('../intelligence.cjs').feedback(deriveSubagentSuccess(summary));
+  } catch (e) { /* non-fatal — feedback recording must never block subagent-stop */ }
+
   if (!org && !session) {
     // No active org or session — log to general capture file only
     // P2-26: rotate — was a pure appendFileSync with no cap, unlike
@@ -486,16 +509,7 @@ async function handleSubagentStop(hookInput) {
             tokens_in: totalTin || 0,
             tokens_out: totalTout || 0,
             cost_usd: costUsd || 0,
-            success: (function() {
-              // Determine success from result summary — errors/failures/exceptions indicate failure
-              if (summary) {
-                var sumLower = summary.toLowerCase();
-                if (sumLower.includes('error') || sumLower.includes('failed') || sumLower.includes('exception') || sumLower.includes('fatal')) {
-                  return 0;
-                }
-              }
-              return 1;
-            })(),
+            success: deriveSubagentSuccess(summary) ? 1 : 0,
             duration_ms: snap.ts ? (Date.now() - snap.ts) : 0,
             timestamp: Date.now(),
           });

--- a/packages/@monomind/cli/src/commands/doctor-env-checks.ts
+++ b/packages/@monomind/cli/src/commands/doctor-env-checks.ts
@@ -94,6 +94,11 @@ export async function checkDiskSpace(): Promise<HealthCheck> {
 }
 
 export async function checkBuildTools(): Promise<HealthCheck> {
+  // Only meaningful for Node/TS projects — a Go, Python, or Rust repo has no
+  // reason to install TypeScript, and warning about it there is just noise.
+  if (!existsSync(join(process.cwd(), 'package.json'))) {
+    return { name: 'TypeScript', status: 'pass', message: 'N/A — no package.json (not a Node.js project)' };
+  }
   try {
     const tscVersion = await runCommand('npx tsc --version', 10000);
     if (!tscVersion || tscVersion.includes('not found')) {


### PR DESCRIPTION
## Summary
- **Routing-feedback success flag was structurally always true.** The only writer of `false` outcomes was `task-handler.cjs`'s `handlePostTask`, wired to `TeammateIdle`/`TaskCompleted` — events that aren't valid Claude Code hooks (already stripped from generated `settings.json` elsewhere in this codebase) and so never fire; that path is dead code. The remaining writer, `session-handler.cjs`'s `SessionEnd` heuristic, derives success almost entirely from "did a commit happen in the last 30 minutes" (true for nearly every real session), and its intended veto — checking recent `intelligence-outcomes.jsonl` for a majority of real failures — could never fire because nothing fed it genuine failure data anymore. Result: `doctor` always reported "success flag is degenerate (100% true — sessionSuccess heuristic never records failure)".
- `capture-handler.cjs`'s `SubagentStop` handler already computes a real success/failure classification per subagent (used for the Monograph `agent_interactions.success` column — keyword-based on the result summary). It just never fed that into `intelligence.feedback()`, the same sink the session-end veto reads. Wired it through, deduping the classification logic into a shared `deriveSubagentSuccess()` helper used by both the Monograph write and the new `feedback()` call.
- Also scoped `doctor`'s TypeScript check to skip non-Node projects (no `package.json`) instead of unconditionally warning "Not installed locally" — meaningless noise on a Go/Python/Rust repo.

## Test plan
- [x] Scratch integration test (`node subagent-start` → write a failing transcript → `node subagent-stop` → assert on `intelligence-outcomes.jsonl`): confirmed it fails without the fix (`intelligence-outcomes.jsonl was never created`) and passes with it, for both a success and a failure transcript.
- [x] Full pipeline test in a fresh project: committed a change (so the commit-based heuristic would say "true"), simulated a failing subagent, ran the real `session-end` hook — confirmed `routing-feedback.jsonl` correctly recorded `intelligenceFeedback: false` (the veto worked), and `doctor` reported `✓ Routing Learning` with a real success rate instead of the degenerate warning.
- [x] Verified the TypeScript check: now passes with "N/A — no package.json" on a Go project (previously warned), and still correctly reports the real installed version on a genuine TS project (this repo) — no regression.
- [x] `npx vitest run __tests__/init-e2e.test.ts __tests__/monovector/init-state.test.ts __tests__/p1-commands.test.ts` — 55/55 passing.
- [x] `node --check` on both edited `.cjs` files and the compiled `.js` output.