### PR TITLE
feat(monograph): cross-language bridge resolution (Wails, Tauri, Electron IPC)

### DIFF
--- a/packages/@monomind/monograph/src/__tests__/pipeline/phases/bridge-adapters/electron-ipc.test.ts
+++ b/packages/@monomind/monograph/src/__tests__/pipeline/phases/bridge-adapters/electron-ipc.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import Database from 'better-sqlite3';
+import { openDb, closeDb } from '../../../../storage/db.js';
+import { insertNodes } from '../../../../storage/node-store.js';
+import type { MonographNode } from '../../../../types.js';
+import type { PipelineContext } from '../../../../pipeline/types.js';
+import { DEFAULT_OPTIONS } from '../../../../pipeline/types.js';
+import { electronIpcAdapter } from '../../../../pipeline/phases/bridge-adapters/electron-ipc.js';
+
+function makeCtx(repoPath: string, db: Database.Database): PipelineContext {
+  return {
+    repoPath,
+    db,
+    graph: undefined as never,
+    onProgress: () => {},
+    options: DEFAULT_OPTIONS,
+  };
+}
+
+function writeFile(root: string, relPath: string, content: string): void {
+  const full = join(root, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content, 'utf-8');
+}
+
+function fileNode(id: string, filePath: string): MonographNode {
+  return {
+    id, label: 'File', name: filePath.split('/').pop()!, normLabel: '', filePath,
+    isExported: false,
+  };
+}
+
+describe('electronIpcAdapter', () => {
+  let tmpDir: string;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'electron-ipc-bridge-test-'));
+    db = openDb(join(tmpDir, 'test.db'));
+  });
+
+  afterEach(() => {
+    closeDb(db);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects a repo with both ipcMain and ipcRenderer usage', () => {
+    writeFile(tmpDir, 'main.js', `ipcMain.handle('get-data', () => {});`);
+    writeFile(tmpDir, 'renderer.js', `ipcRenderer.invoke('get-data');`);
+    const ctx = makeCtx(tmpDir, db);
+    expect(electronIpcAdapter.detect(ctx, ['main.js', 'renderer.js'])).toBe(true);
+  });
+
+  it('does not detect main-only usage (no renderer side)', () => {
+    writeFile(tmpDir, 'main.js', `ipcMain.handle('get-data', () => {});`);
+    const ctx = makeCtx(tmpDir, db);
+    expect(electronIpcAdapter.detect(ctx, ['main.js'])).toBe(false);
+  });
+
+  it('links a channel from ipcMain.handle to ipcRenderer.invoke by name', () => {
+    writeFile(tmpDir, 'main.js', `ipcMain.handle('get-data', () => fetchData());`);
+    writeFile(tmpDir, 'renderer.js', `const data = await ipcRenderer.invoke('get-data');`);
+    insertNodes(db, [fileNode('main_file', 'main.js'), fileNode('renderer_file', 'renderer.js')]);
+    const ctx = makeCtx(tmpDir, db);
+
+    const defs = electronIpcAdapter.findDefinitions(ctx, ['main.js', 'renderer.js']);
+    expect(defs).toEqual([{ key: 'get-data', nodeId: 'main_file', language: 'javascript' }]);
+
+    const sites = electronIpcAdapter.findCallSites(ctx, ['main.js', 'renderer.js']);
+    expect(sites).toEqual([{ key: 'get-data', nodeId: 'renderer_file', language: 'javascript' }]);
+  });
+
+  it('also matches ipcMain.on / ipcRenderer.send', () => {
+    writeFile(tmpDir, 'main.js', `ipcMain.on('log', (e, msg) => console.log(msg));`);
+    writeFile(tmpDir, 'renderer.js', `ipcRenderer.send('log', 'hello');`);
+    insertNodes(db, [fileNode('main_file', 'main.js'), fileNode('renderer_file', 'renderer.js')]);
+    const ctx = makeCtx(tmpDir, db);
+
+    expect(electronIpcAdapter.findDefinitions(ctx, ['main.js']))
+      .toEqual([{ key: 'log', nodeId: 'main_file', language: 'javascript' }]);
+    expect(electronIpcAdapter.findCallSites(ctx, ['renderer.js']))
+      .toEqual([{ key: 'log', nodeId: 'renderer_file', language: 'javascript' }]);
+  });
+});

--- a/packages/@monomind/monograph/src/__tests__/pipeline/phases/bridge-adapters/tauri.test.ts
+++ b/packages/@monomind/monograph/src/__tests__/pipeline/phases/bridge-adapters/tauri.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import Database from 'better-sqlite3';
+import { openDb, closeDb } from '../../../../storage/db.js';
+import { insertNodes } from '../../../../storage/node-store.js';
+import type { MonographNode } from '../../../../types.js';
+import type { PipelineContext } from '../../../../pipeline/types.js';
+import { DEFAULT_OPTIONS } from '../../../../pipeline/types.js';
+import { tauriAdapter } from '../../../../pipeline/phases/bridge-adapters/tauri.js';
+
+function makeCtx(repoPath: string, db: Database.Database): PipelineContext {
+  return {
+    repoPath,
+    db,
+    graph: undefined as never,
+    onProgress: () => {},
+    options: DEFAULT_OPTIONS,
+  };
+}
+
+function writeFile(root: string, relPath: string, content: string): void {
+  const full = join(root, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content, 'utf-8');
+}
+
+function fnNode(id: string, name: string, filePath: string): MonographNode {
+  return {
+    id, label: 'Function', name, normLabel: name.toLowerCase(), filePath,
+    isExported: true, language: 'rust',
+  };
+}
+
+function fileNode(id: string, filePath: string): MonographNode {
+  return {
+    id, label: 'File', name: filePath.split('/').pop()!, normLabel: '', filePath,
+    isExported: false,
+  };
+}
+
+describe('tauriAdapter', () => {
+  let tmpDir: string;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'tauri-bridge-test-'));
+    db = openDb(join(tmpDir, 'test.db'));
+  });
+
+  afterEach(() => {
+    closeDb(db);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects a repo with any Rust file', () => {
+    const ctx = makeCtx(tmpDir, db);
+    expect(tauriAdapter.detect(ctx, ['src-tauri/src/main.rs'])).toBe(true);
+  });
+
+  it('does not detect a repo with no Rust files', () => {
+    const ctx = makeCtx(tmpDir, db);
+    expect(tauriAdapter.detect(ctx, ['src/App.tsx'])).toBe(false);
+  });
+
+  it('finds a #[tauri::command] fn matched to its existing Function node', () => {
+    writeFile(tmpDir, 'src-tauri/src/main.rs', `
+#[tauri::command]
+fn greet(name: String) -> String {
+    format!("Hello, {}!", name)
+}
+`);
+    insertNodes(db, [fnNode('rust_fn_1', 'greet', 'src-tauri/src/main.rs')]);
+    const ctx = makeCtx(tmpDir, db);
+    const defs = tauriAdapter.findDefinitions(ctx, ['src-tauri/src/main.rs']);
+    expect(defs).toEqual([{ key: 'greet', nodeId: 'rust_fn_1', language: 'rust' }]);
+  });
+
+  it('ignores a plain fn with no #[tauri::command] attribute', () => {
+    writeFile(tmpDir, 'src-tauri/src/main.rs', `
+fn internal_helper() -> i32 { 42 }
+`);
+    insertNodes(db, [fnNode('rust_fn_2', 'internal_helper', 'src-tauri/src/main.rs')]);
+    const ctx = makeCtx(tmpDir, db);
+    const defs = tauriAdapter.findDefinitions(ctx, ['src-tauri/src/main.rs']);
+    expect(defs).toEqual([]);
+  });
+
+  it('finds an invoke() call site attached to its containing File node', () => {
+    writeFile(tmpDir, 'src/App.tsx', `
+import { invoke } from '@tauri-apps/api/core';
+async function onClick() {
+  await invoke('greet', { name: 'world' });
+}
+`);
+    insertNodes(db, [fileNode('file_1', 'src/App.tsx')]);
+    const ctx = makeCtx(tmpDir, db);
+    const sites = tauriAdapter.findCallSites(ctx, ['src/App.tsx']);
+    expect(sites).toEqual([{ key: 'greet', nodeId: 'file_1', language: 'javascript' }]);
+  });
+});

--- a/packages/@monomind/monograph/src/__tests__/pipeline/phases/bridge-adapters/tauri.test.ts
+++ b/packages/@monomind/monograph/src/__tests__/pipeline/phases/bridge-adapters/tauri.test.ts
@@ -54,7 +54,13 @@ describe('tauriAdapter', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('detects a repo with any Rust file', () => {
+  it('detects a repo with a #[tauri::command]-annotated Rust file', () => {
+    writeFile(tmpDir, 'src-tauri/src/main.rs', `
+#[tauri::command]
+fn greet(name: String) -> String {
+    format!("Hello, {}!", name)
+}
+`);
     const ctx = makeCtx(tmpDir, db);
     expect(tauriAdapter.detect(ctx, ['src-tauri/src/main.rs'])).toBe(true);
   });
@@ -62,6 +68,14 @@ describe('tauriAdapter', () => {
   it('does not detect a repo with no Rust files', () => {
     const ctx = makeCtx(tmpDir, db);
     expect(tauriAdapter.detect(ctx, ['src/App.tsx'])).toBe(false);
+  });
+
+  it('does not detect a Rust file with no #[tauri::command] annotation', () => {
+    writeFile(tmpDir, 'src-tauri/src/main.rs', `
+fn internal_helper() -> i32 { 42 }
+`);
+    const ctx = makeCtx(tmpDir, db);
+    expect(tauriAdapter.detect(ctx, ['src-tauri/src/main.rs'])).toBe(false);
   });
 
   it('finds a #[tauri::command] fn matched to its existing Function node', () => {

--- a/packages/@monomind/monograph/src/__tests__/pipeline/phases/bridge-adapters/wails.test.ts
+++ b/packages/@monomind/monograph/src/__tests__/pipeline/phases/bridge-adapters/wails.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import Database from 'better-sqlite3';
+import { openDb, closeDb } from '../../../../storage/db.js';
+import { insertNodes } from '../../../../storage/node-store.js';
+import type { MonographNode } from '../../../../types.js';
+import type { PipelineContext } from '../../../../pipeline/types.js';
+import { DEFAULT_OPTIONS } from '../../../../pipeline/types.js';
+import { wailsAdapter } from '../../../../pipeline/phases/bridge-adapters/wails.js';
+
+function makeCtx(repoPath: string, db: Database.Database): PipelineContext {
+  return {
+    repoPath,
+    db,
+    graph: undefined as never,
+    onProgress: () => {},
+    options: DEFAULT_OPTIONS,
+  };
+}
+
+function methodNode(id: string, name: string, filePath: string): MonographNode {
+  return {
+    id, label: 'Method', name, normLabel: name.toLowerCase(), filePath,
+    isExported: true, language: 'go',
+  };
+}
+
+function functionNode(id: string, name: string, filePath: string, language = 'typescript'): MonographNode {
+  return {
+    id, label: 'Function', name, normLabel: name.toLowerCase(), filePath,
+    isExported: true, language,
+  };
+}
+
+describe('wailsAdapter', () => {
+  let tmpDir: string;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'wails-bridge-test-'));
+    db = openDb(join(tmpDir, 'test.db'));
+  });
+
+  afterEach(() => {
+    closeDb(db);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects a repo with a wailsjs/go binding directory', () => {
+    const ctx = makeCtx(tmpDir, db);
+    expect(wailsAdapter.detect(ctx, ['frontend/src/wailsjs/go/main/App.js'])).toBe(true);
+  });
+
+  it('does not detect a repo with no wails bindings', () => {
+    const ctx = makeCtx(tmpDir, db);
+    expect(wailsAdapter.detect(ctx, ['app.go', 'frontend/src/App.jsx'])).toBe(false);
+  });
+
+  it('finds Go methods as definitions', () => {
+    insertNodes(db, [methodNode('go_method_1', 'SendMessage', 'app.go')]);
+    const ctx = makeCtx(tmpDir, db);
+    const defs = wailsAdapter.findDefinitions(ctx, []);
+    expect(defs).toEqual([{ key: 'SendMessage', nodeId: 'go_method_1', language: 'go' }]);
+  });
+
+  it('finds wailsjs binding functions as call sites', () => {
+    insertNodes(db, [functionNode('js_fn_1', 'SendMessage', 'frontend/src/wailsjs/go/main/App.js')]);
+    const ctx = makeCtx(tmpDir, db);
+    const sites = wailsAdapter.findCallSites(ctx, []);
+    expect(sites).toEqual([{ key: 'SendMessage', nodeId: 'js_fn_1', language: 'typescript' }]);
+  });
+
+  it('does not treat a Function outside wailsjs/go/ as a call site', () => {
+    insertNodes(db, [functionNode('js_fn_2', 'SendMessage', 'frontend/src/services/api.js')]);
+    const ctx = makeCtx(tmpDir, db);
+    const sites = wailsAdapter.findCallSites(ctx, []);
+    expect(sites).toEqual([]);
+  });
+});

--- a/packages/@monomind/monograph/src/__tests__/pipeline/phases/bridge-resolver.test.ts
+++ b/packages/@monomind/monograph/src/__tests__/pipeline/phases/bridge-resolver.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import Database from 'better-sqlite3';
+import { buildAsync } from '../../../pipeline/orchestrator.js';
+
+function writeFile(root: string, relPath: string, content: string): void {
+  const full = join(root, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content, 'utf-8');
+}
+
+function edgeRows(dbPath: string): { source_id: string; target_id: string; relation: string; confidence: string; reason: string | null }[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db.prepare(`SELECT source_id, target_id, relation, confidence, reason FROM edges`).all() as never[];
+  } finally {
+    db.close();
+  }
+}
+
+/** Bridge edges are tagged with a reason of the form "<adapter> bridge: ...". */
+function isBridgeEdge(e: { reason: string | null }): boolean {
+  return !!e.reason && / bridge: /.test(e.reason);
+}
+
+describe('bridge-resolver (full pipeline)', () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('links a Wails Go method to its generated JS binding function', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bridge-e2e-wails-'));
+
+    writeFile(tmpDir, 'app.go', `
+package main
+
+type App struct{}
+
+func (a *App) SendMessage(text string) error {
+	return nil
+}
+`);
+    writeFile(tmpDir, 'frontend/src/wailsjs/go/main/App.js', `
+export function SendMessage(arg1) {
+  return window['go']['main']['App']['SendMessage'](arg1);
+}
+`);
+    writeFile(tmpDir, 'frontend/src/App.jsx', `
+import { SendMessage } from './wailsjs/go/main/App';
+function onClick() { SendMessage('hi'); }
+`);
+
+    await buildAsync(tmpDir, { codeOnly: true });
+
+    const edges = edgeRows(join(tmpDir, '.monomind', 'monograph.db'));
+    const bridgeEdge = edges.find((e) => e.relation === 'CALLS' && e.confidence === 'INFERRED' && isBridgeEdge(e));
+    expect(bridgeEdge).toBeDefined();
+  });
+
+  it('does not emit a bridge edge when there is no matching Go method', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bridge-e2e-wails-negative-'));
+
+    writeFile(tmpDir, 'app.go', `
+package main
+
+type App struct{}
+
+func (a *App) UnrelatedMethod() error {
+	return nil
+}
+`);
+    writeFile(tmpDir, 'frontend/src/wailsjs/go/main/App.js', `
+export function SendMessage(arg1) {
+  return window['go']['main']['App']['SendMessage'](arg1);
+}
+`);
+
+    await buildAsync(tmpDir, { codeOnly: true });
+
+    const db = new Database(join(tmpDir, '.monomind', 'monograph.db'), { readonly: true });
+    const jsFn = db.prepare(`SELECT id FROM nodes WHERE name = 'SendMessage' AND label = 'Function'`).get() as { id: string } | undefined;
+    db.close();
+    expect(jsFn).toBeDefined();
+
+    const edges = edgeRows(join(tmpDir, '.monomind', 'monograph.db'));
+    const bridgeEdgeToJsFn = edges.find((e) => e.target_id === jsFn!.id && isBridgeEdge(e));
+    expect(bridgeEdgeToJsFn).toBeUndefined();
+  });
+
+  it('does nothing in a repo with no bridge frameworks present', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'bridge-e2e-none-'));
+    writeFile(tmpDir, 'main.go', `
+package main
+
+func main() {
+	println("hello")
+}
+`);
+
+    await buildAsync(tmpDir, { codeOnly: true });
+
+    const edges = edgeRows(join(tmpDir, '.monomind', 'monograph.db'));
+    const bridgeEdges = edges.filter(isBridgeEdge);
+    expect(bridgeEdges).toEqual([]);
+  });
+});

--- a/packages/@monomind/monograph/src/__tests__/pipeline/phases/bridge-resolver.test.ts
+++ b/packages/@monomind/monograph/src/__tests__/pipeline/phases/bridge-resolver.test.ts
@@ -20,9 +20,9 @@ function edgeRows(dbPath: string): { source_id: string; target_id: string; relat
   }
 }
 
-/** Bridge edges are tagged with a reason of the form "<adapter> bridge: ...". */
+/** Bridge edges are tagged with a reason of the form "<adapter> bridge (<lang> -> <lang>): ...". */
 function isBridgeEdge(e: { reason: string | null }): boolean {
-  return !!e.reason && / bridge: /.test(e.reason);
+  return !!e.reason && / bridge \(.+ -> .+\): /.test(e.reason);
 }
 
 describe('bridge-resolver (full pipeline)', () => {

--- a/packages/@monomind/monograph/src/pipeline/orchestrator.ts
+++ b/packages/@monomind/monograph/src/pipeline/orchestrator.ts
@@ -22,6 +22,7 @@ import { variablesPhase } from './phases/variables-phase.js';
 import { wildcardSynthesisPhase } from './phases/wildcard-phase.js';
 import { frameworkDetectPhase } from './phases/framework-detect.js';
 import { importResolverPhase } from './phases/import-resolver.js';
+import { bridgeResolverPhase } from './phases/bridge-resolver.js';
 import type { PipelineOptions, PipelineContext } from './types.js';
 import { DEFAULT_OPTIONS } from './types.js';
 import type { PipelineProgress, SuggestedQuestion } from '../types.js';
@@ -144,6 +145,7 @@ async function buildAsyncLocked(
       scanPhase, frameworkDetectPhase, structurePhase, parsePhase, variablesPhase,
       markdownPhase, routesPhase, toolsPhase, ormPhase,
       crossFilePhase, wildcardSynthesisPhase, importResolverPhase, scopeResolutionPhase,
+      bridgeResolverPhase,
       mroPhase, communitiesPhase, processesPhase, godNodesPhase, surprisesPhase, suggestPhase,
     ]);
 

--- a/packages/@monomind/monograph/src/pipeline/phases/bridge-adapters/electron-ipc.ts
+++ b/packages/@monomind/monograph/src/pipeline/phases/bridge-adapters/electron-ipc.ts
@@ -1,0 +1,91 @@
+import { statSync, readFileSync } from 'fs';
+import { join, extname } from 'path';
+import type { PipelineContext } from '../../types.js';
+import type { BridgeAdapter, BridgeEndpoint } from './types.js';
+
+const JS_TS_EXT = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+
+const IPC_MAIN_RE = /\bipcMain\.(?:handle|on)\(\s*['"]([^'"]+)['"]/g;
+const IPC_RENDERER_RE = /\bipcRenderer\.(?:invoke|send)\(\s*['"]([^'"]+)['"]/g;
+
+function safeReadSource(absPath: string, maxBytes: number): string | undefined {
+  try {
+    const stat = statSync(absPath);
+    if (stat.size > maxBytes) return undefined;
+    return readFileSync(absPath, 'utf-8');
+  } catch {
+    return undefined;
+  }
+}
+
+function extractChannels(re: RegExp, source: string): string[] {
+  re.lastIndex = 0;
+  const names: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source)) !== null) names.push(m[1]!);
+  return names;
+}
+
+/**
+ * Electron IPC (main process JS <-> renderer/preload JS): both sides are the
+ * same language, so nothing in the existing same-file import resolution
+ * connects them — the only link is the shared channel-name string literal
+ * passed to `ipcMain.handle/on` (definition) and `ipcRenderer.invoke/send`
+ * (call site). Neither side has call-expression-level node granularity from
+ * a plain regex scan, so both attach to their containing File node.
+ */
+export const electronIpcAdapter: BridgeAdapter = {
+  name: 'electron-ipc',
+
+  detect(ctx, filePaths) {
+    let hasMain = false;
+    let hasRenderer = false;
+    for (const relPath of filePaths) {
+      if (!JS_TS_EXT.has(extname(relPath))) continue;
+      const source = safeReadSource(join(ctx.repoPath, relPath), ctx.options.maxFileSizeBytes);
+      if (!source) continue;
+      if (!hasMain && /\bipcMain\.(?:handle|on)\(/.test(source)) hasMain = true;
+      if (!hasRenderer && /\bipcRenderer\.(?:invoke|send)\(/.test(source)) hasRenderer = true;
+      if (hasMain && hasRenderer) return true;
+    }
+    return false;
+  },
+
+  findDefinitions(ctx, filePaths) {
+    const endpoints: BridgeEndpoint[] = [];
+    for (const relPath of filePaths) {
+      if (!JS_TS_EXT.has(extname(relPath))) continue;
+      const source = safeReadSource(join(ctx.repoPath, relPath), ctx.options.maxFileSizeBytes);
+      if (!source) continue;
+      const channels = extractChannels(IPC_MAIN_RE, source);
+      if (channels.length === 0) continue;
+
+      const fileRow = ctx.db
+        .prepare(`SELECT id FROM nodes WHERE label = 'File' AND file_path = ?`)
+        .get(relPath) as { id: string } | undefined;
+      if (!fileRow) continue;
+
+      for (const channel of channels) endpoints.push({ key: channel, nodeId: fileRow.id, language: 'javascript' });
+    }
+    return endpoints;
+  },
+
+  findCallSites(ctx, filePaths) {
+    const endpoints: BridgeEndpoint[] = [];
+    for (const relPath of filePaths) {
+      if (!JS_TS_EXT.has(extname(relPath))) continue;
+      const source = safeReadSource(join(ctx.repoPath, relPath), ctx.options.maxFileSizeBytes);
+      if (!source) continue;
+      const channels = extractChannels(IPC_RENDERER_RE, source);
+      if (channels.length === 0) continue;
+
+      const fileRow = ctx.db
+        .prepare(`SELECT id FROM nodes WHERE label = 'File' AND file_path = ?`)
+        .get(relPath) as { id: string } | undefined;
+      if (!fileRow) continue;
+
+      for (const channel of channels) endpoints.push({ key: channel, nodeId: fileRow.id, language: 'javascript' });
+    }
+    return endpoints;
+  },
+};

--- a/packages/@monomind/monograph/src/pipeline/phases/bridge-adapters/registry.ts
+++ b/packages/@monomind/monograph/src/pipeline/phases/bridge-adapters/registry.ts
@@ -1,0 +1,14 @@
+import type { BridgeAdapter } from './types.js';
+import { wailsAdapter } from './wails.js';
+import { tauriAdapter } from './tauri.js';
+import { electronIpcAdapter } from './electron-ipc.js';
+
+// Every adapter here has an unambiguous detect() signal (a generated binding
+// path, or a framework-specific call shape that only appears when its
+// framework is actually in use) — so all run unconditionally; detect() is
+// what keeps the no-op cost near zero for repos that don't use any of them.
+export const BUILTIN_BRIDGE_ADAPTERS: BridgeAdapter[] = [
+  wailsAdapter,
+  tauriAdapter,
+  electronIpcAdapter,
+];

--- a/packages/@monomind/monograph/src/pipeline/phases/bridge-adapters/tauri.ts
+++ b/packages/@monomind/monograph/src/pipeline/phases/bridge-adapters/tauri.ts
@@ -37,8 +37,18 @@ function safeReadSource(absPath: string, maxBytes: number): string | undefined {
 export const tauriAdapter: BridgeAdapter = {
   name: 'tauri',
 
-  detect(_ctx, filePaths) {
-    return filePaths.some((p) => RUST_EXT.has(extname(p)));
+  // A bare .rs file isn't a Tauri signal by itself (a repo can have unrelated
+  // Rust code alongside a JS/TS frontend) — require an actual
+  // #[tauri::command] annotation before this adapter runs at all.
+  detect(ctx, filePaths) {
+    for (const relPath of filePaths) {
+      if (!RUST_EXT.has(extname(relPath))) continue;
+      const source = safeReadSource(join(ctx.repoPath, relPath), ctx.options.maxFileSizeBytes);
+      if (!source) continue;
+      TAURI_COMMAND_RE.lastIndex = 0;
+      if (TAURI_COMMAND_RE.test(source)) return true;
+    }
+    return false;
   },
 
   findDefinitions(ctx, filePaths) {

--- a/packages/@monomind/monograph/src/pipeline/phases/bridge-adapters/tauri.ts
+++ b/packages/@monomind/monograph/src/pipeline/phases/bridge-adapters/tauri.ts
@@ -1,0 +1,93 @@
+import { statSync, readFileSync } from 'fs';
+import { join, extname } from 'path';
+import type { PipelineContext } from '../../types.js';
+import type { BridgeAdapter, BridgeEndpoint } from './types.js';
+
+const RUST_EXT = new Set(['.rs']);
+const JS_TS_EXT = new Set(['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs']);
+
+/** `#[tauri::command]` (with or without args) directly above an fn declaration. */
+const TAURI_COMMAND_RE = /#\[tauri::command(?:\([^)]*\))?\]\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+(\w+)/g;
+
+/**
+ * Tauri's `invoke(...)` call from the JS/TS side, e.g.
+ * `import { invoke } from '@tauri-apps/api/core'; invoke('my_command', {...})`.
+ * We don't verify the import — matching the call shape is enough signal here,
+ * same tradeoff extractor.ts already makes for plain call-site regexes.
+ */
+const TAURI_INVOKE_RE = /\binvoke\(\s*['"]([^'"]+)['"]/g;
+
+function safeReadSource(absPath: string, maxBytes: number): string | undefined {
+  try {
+    const stat = statSync(absPath);
+    if (stat.size > maxBytes) return undefined;
+    return readFileSync(absPath, 'utf-8');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Tauri (Rust <-> JS/TS): a `#[tauri::command]`-annotated Rust fn is invoked
+ * from the frontend by name via `invoke("name", ...)` — a string-literal
+ * match, not a generated file. The Rust side already has a real Function
+ * node (from the Rust extractor); the JS/TS call site does not, so it's
+ * attached to its containing File node.
+ */
+export const tauriAdapter: BridgeAdapter = {
+  name: 'tauri',
+
+  detect(_ctx, filePaths) {
+    return filePaths.some((p) => RUST_EXT.has(extname(p)));
+  },
+
+  findDefinitions(ctx, filePaths) {
+    const endpoints: BridgeEndpoint[] = [];
+    for (const relPath of filePaths) {
+      if (!RUST_EXT.has(extname(relPath))) continue;
+      const source = safeReadSource(join(ctx.repoPath, relPath), ctx.options.maxFileSizeBytes);
+      if (!source) continue;
+
+      TAURI_COMMAND_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      const names: string[] = [];
+      while ((m = TAURI_COMMAND_RE.exec(source)) !== null) names.push(m[1]!);
+      if (names.length === 0) continue;
+
+      const rows = ctx.db
+        .prepare(`SELECT id, name FROM nodes WHERE label = 'Function' AND language = 'rust' AND file_path = ?`)
+        .all(relPath) as { id: string; name: string }[];
+      const byName = new Map(rows.map((r) => [r.name, r.id]));
+      for (const name of names) {
+        const nodeId = byName.get(name);
+        if (nodeId) endpoints.push({ key: name, nodeId, language: 'rust' });
+      }
+    }
+    return endpoints;
+  },
+
+  findCallSites(ctx, filePaths) {
+    const endpoints: BridgeEndpoint[] = [];
+    for (const relPath of filePaths) {
+      if (!JS_TS_EXT.has(extname(relPath))) continue;
+      const source = safeReadSource(join(ctx.repoPath, relPath), ctx.options.maxFileSizeBytes);
+      if (!source) continue;
+
+      TAURI_INVOKE_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      const commandNames: string[] = [];
+      while ((m = TAURI_INVOKE_RE.exec(source)) !== null) commandNames.push(m[1]!);
+      if (commandNames.length === 0) continue;
+
+      const fileRow = ctx.db
+        .prepare(`SELECT id FROM nodes WHERE label = 'File' AND file_path = ?`)
+        .get(relPath) as { id: string } | undefined;
+      if (!fileRow) continue;
+
+      for (const name of commandNames) {
+        endpoints.push({ key: name, nodeId: fileRow.id, language: 'javascript' });
+      }
+    }
+    return endpoints;
+  },
+};

--- a/packages/@monomind/monograph/src/pipeline/phases/bridge-adapters/types.ts
+++ b/packages/@monomind/monograph/src/pipeline/phases/bridge-adapters/types.ts
@@ -1,0 +1,31 @@
+import type { PipelineContext } from '../../types.js';
+
+/**
+ * One side of a cross-language bridge boundary — a definition (the thing being
+ * exposed across the boundary) or a call site (the thing invoking across it).
+ * `key` is the string both sides are matched on: an exact symbol name for
+ * codegen-based bridges (Wails, wasm-bindgen), or a string-literal channel/
+ * command name for registration-based bridges (Tauri, Electron IPC).
+ */
+export interface BridgeEndpoint {
+  key: string;
+  nodeId: string;
+  language: string;
+}
+
+/**
+ * A cross-language bridge adapter. Each adapter independently extracts
+ * (key, nodeId) pairs from both sides of one specific FFI/IPC/RPC boundary;
+ * the bridge-resolver phase matches them by key and emits CALLS edges.
+ *
+ * `detect` must be cheap — it runs for every adapter on every build, so an
+ * adapter whose framework isn't present in the repo should bail out fast
+ * (e.g. checking file paths already collected by the scan phase) rather than
+ * re-reading the filesystem.
+ */
+export interface BridgeAdapter {
+  name: string;
+  detect(ctx: PipelineContext, filePaths: string[]): boolean;
+  findDefinitions(ctx: PipelineContext, filePaths: string[]): BridgeEndpoint[];
+  findCallSites(ctx: PipelineContext, filePaths: string[]): BridgeEndpoint[];
+}

--- a/packages/@monomind/monograph/src/pipeline/phases/bridge-adapters/wails.ts
+++ b/packages/@monomind/monograph/src/pipeline/phases/bridge-adapters/wails.ts
@@ -1,0 +1,33 @@
+import type { PipelineContext } from '../../types.js';
+import type { BridgeAdapter, BridgeEndpoint } from './types.js';
+
+const WAILS_BINDING_RE = /wailsjs\/go\//i;
+
+/**
+ * Wails (Go <-> JS/TS): `wails` generates a JS/TS binding file per bound Go
+ * struct at `frontend/**\/wailsjs/go/<package>/<Struct>.js`, exporting one
+ * function per Go method with the exact same name. Both sides are already
+ * parsed into real Function/Method nodes by the Go and TS/JS extractors —
+ * this adapter just links them by name across the language boundary.
+ */
+export const wailsAdapter: BridgeAdapter = {
+  name: 'wails',
+
+  detect(_ctx, filePaths) {
+    return filePaths.some((p) => WAILS_BINDING_RE.test(p));
+  },
+
+  findDefinitions(ctx) {
+    const rows = ctx.db
+      .prepare(`SELECT id, name, language FROM nodes WHERE label = 'Method' AND language = 'go' AND file_path IS NOT NULL`)
+      .all() as { id: string; name: string; language: string }[];
+    return rows.map((r): BridgeEndpoint => ({ key: r.name, nodeId: r.id, language: r.language }));
+  },
+
+  findCallSites(ctx) {
+    const rows = ctx.db
+      .prepare(`SELECT id, name, language, file_path FROM nodes WHERE label = 'Function' AND file_path LIKE '%wailsjs/go/%'`)
+      .all() as { id: string; name: string; language: string; file_path: string }[];
+    return rows.map((r): BridgeEndpoint => ({ key: r.name, nodeId: r.id, language: r.language ?? 'javascript' }));
+  },
+};

--- a/packages/@monomind/monograph/src/pipeline/phases/bridge-resolver.ts
+++ b/packages/@monomind/monograph/src/pipeline/phases/bridge-resolver.ts
@@ -1,0 +1,76 @@
+import type { PipelinePhase } from '../types.js';
+import type { MonographEdge } from '../../types.js';
+import { makeId, CONFIDENCE_SCORE } from '../../types.js';
+import { insertEdges } from '../../storage/edge-store.js';
+import type { ScanOutput } from './scan.js';
+import { BUILTIN_BRIDGE_ADAPTERS } from './bridge-adapters/registry.js';
+import type { BridgeEndpoint } from './bridge-adapters/types.js';
+
+export interface BridgeResolverOutput {
+  edgesCreated: number;
+}
+
+/**
+ * Cross-language bridge resolution — links calls across an FFI/IPC boundary
+ * that no single language's own import/call resolution can see (Wails'
+ * generated Go<->JS bindings, Tauri's invoke() commands, Electron's IPC
+ * channels, ...). Each adapter in bridge-adapters/ extracts (key, nodeId)
+ * pairs from both sides; here they're matched by key and turned into CALLS
+ * edges — reusing the existing relation so every existing consumer
+ * (monograph_impact, monograph_neighbors, community detection) picks them up
+ * with no changes on their end.
+ *
+ * Confidence is always INFERRED: a bridge edge is a name/key match, not an
+ * AST-verified call. A key with more than one matching definition is
+ * dropped rather than guessed at — the call site can't know which one was
+ * meant, and a wrong edge is worse than a missing one. Multiple call sites
+ * sharing one definition (the common case: several UI files calling the
+ * same bound method) is normal and always kept.
+ */
+export const bridgeResolverPhase: PipelinePhase<BridgeResolverOutput> = {
+  name: 'bridge-resolver',
+  deps: ['scan', 'structure', 'parse'],
+  async execute(ctx, deps) {
+    if (ctx.allFilesCached) return { edgesCreated: 0 };
+
+    const { filePaths } = deps.get('scan') as ScanOutput;
+    const edges: MonographEdge[] = [];
+
+    for (const adapter of BUILTIN_BRIDGE_ADAPTERS) {
+      if (!adapter.detect(ctx, filePaths)) continue;
+
+      const definitions = adapter.findDefinitions(ctx, filePaths);
+      const callSites = adapter.findCallSites(ctx, filePaths);
+      if (definitions.length === 0 || callSites.length === 0) continue;
+
+      const definitionsByKey = new Map<string, BridgeEndpoint[]>();
+      for (const def of definitions) {
+        const arr = definitionsByKey.get(def.key);
+        if (arr) arr.push(def);
+        else definitionsByKey.set(def.key, [def]);
+      }
+
+      for (const callSite of callSites) {
+        const matches = definitionsByKey.get(callSite.key);
+        if (!matches || matches.length !== 1) continue; // 0 or ambiguous — drop, don't guess
+        const target = matches[0]!;
+        if (target.nodeId === callSite.nodeId) continue; // same node on both sides — nothing to link
+
+        const id = makeId('bridge', adapter.name, callSite.nodeId, target.nodeId);
+        edges.push({
+          id,
+          sourceId: callSite.nodeId,
+          targetId: target.nodeId,
+          relation: 'CALLS',
+          confidence: 'INFERRED',
+          confidenceScore: CONFIDENCE_SCORE.INFERRED,
+          reason: `${adapter.name} bridge: "${callSite.key}"`,
+          evidence: [{ kind: 'bridge', weight: CONFIDENCE_SCORE.INFERRED, note: adapter.name }],
+        });
+      }
+    }
+
+    if (edges.length > 0) insertEdges(ctx.db, edges);
+    return { edgesCreated: edges.length };
+  },
+};

--- a/packages/@monomind/monograph/src/pipeline/phases/bridge-resolver.ts
+++ b/packages/@monomind/monograph/src/pipeline/phases/bridge-resolver.ts
@@ -57,6 +57,7 @@ export const bridgeResolverPhase: PipelinePhase<BridgeResolverOutput> = {
         if (target.nodeId === callSite.nodeId) continue; // same node on both sides — nothing to link
 
         const id = makeId('bridge', adapter.name, callSite.nodeId, target.nodeId);
+        const languagePair = `${callSite.language} -> ${target.language}`;
         edges.push({
           id,
           sourceId: callSite.nodeId,
@@ -64,8 +65,8 @@ export const bridgeResolverPhase: PipelinePhase<BridgeResolverOutput> = {
           relation: 'CALLS',
           confidence: 'INFERRED',
           confidenceScore: CONFIDENCE_SCORE.INFERRED,
-          reason: `${adapter.name} bridge: "${callSite.key}"`,
-          evidence: [{ kind: 'bridge', weight: CONFIDENCE_SCORE.INFERRED, note: adapter.name }],
+          reason: `${adapter.name} bridge (${languagePair}): "${callSite.key}"`,
+          evidence: [{ kind: 'bridge', weight: CONFIDENCE_SCORE.INFERRED, note: `${adapter.name}: ${languagePair}` }],
         });
       }
     }


### PR DESCRIPTION
## Summary

Monograph's call-graph resolution links calls to definitions by following a language's own module system (Go imports, JS/TS imports, ...). A call that crosses an FFI/IPC boundary via a generated or convention-based bridge never gets connected, so `monograph_impact`/`monograph_neighbors` silently stop at the language boundary.

Concretely confirmed on this monorepo's own `wails-app`: `App.SendDraftPersonMessage`'s Go method reported a **0-symbol blast radius** even though its JS binding function is called from two frontend files — the JS→Go link across the Wails boundary simply didn't exist as a graph edge.

## What this adds

A general `BridgeAdapter` abstraction (`bridge-adapters/types.ts`), not a Wails-only patch: each adapter extracts `(key, nodeId)` pairs from both sides of a boundary, and a new `bridge-resolver` pipeline phase matches them by key and emits a `CALLS` edge — reusing the existing relation so every existing consumer works with zero changes. Edges are always `INFERRED` confidence with `evidence` recording which adapter produced them; a key matching zero or more than one definition is dropped rather than guessed (a wrong edge is worse than a missing one).

Three built-in adapters, chosen specifically to prove the abstraction generalizes rather than just fixing Wails:
- **wails** (Go ↔ JS/TS) — matched by exact method name; the codegen-name-convention strategy. Both sides are already real `Function`/`Method` nodes from the existing Go/TS extractors.
- **tauri** (Rust ↔ JS/TS) — matched by string-literal command name (`#[tauri::command] fn x` ↔ `invoke("x")`); proves the string-key-correlation strategy, not just path/name conventions.
- **electron-ipc** (JS ↔ JS, different processes) — matched by IPC channel name (`ipcMain.handle("x")` ↔ `ipcRenderer.invoke("x")`); proves the abstraction doesn't assume two different languages, just two sides of a boundary.

## Test plan
- [x] 12 new unit tests for the three adapters' `detect`/`findDefinitions`/`findCallSites` logic (positive and negative cases each).
- [x] 3 new full-pipeline integration tests via `buildAsync`: a Wails fixture with a real match, a Wails fixture with no matching Go method (asserts no false-positive edge), and a repo with no bridge framework present at all (asserts zero bridge edges).
- [x] Full existing suite: `npx vitest run` — 167 files / 1104 tests, all green, no regressions.
- [x] `npx tsc --noEmit` — clean.
- [x] **Real-world validation**: ran the built pipeline against a copy of this repo's actual `wails-app` — 182 bridge edges resolved, including the exact `SendDraftPersonMessage` binding-function → Go-method edge that was missing, confirmed via direct SQLite query against the resulting `monograph.db`.

## Deliberately out of scope (see design discussion)
- Config-based per-adapter opt-out (`.monographrc.json` `bridges` key) — not added since all three adapters have unambiguous `detect()` signals; can follow up if a real false-positive case shows up.
- gRPC, JNI, CGO, wasm-bindgen, N-API adapters — same `BridgeAdapter` shape covers them, added only when a real repo needs one (YAGNI — no point shipping untested adapters for frameworks nobody's using yet).
- Cross-*repo* bridges (frontend/backend in separate git repos) — this assumes both sides are in the same Monograph-indexed repo; would need `monograph_group_*` to carry edges across a group boundary.