### PR TITLE
fix(hooks): resolve #144 — decouple confirmPort() from the 5s SessionStart hook timeout

### DIFF
--- a/.claude/helpers/control-start.cjs
+++ b/.claude/helpers/control-start.cjs
@@ -119,6 +119,29 @@ function probeStatus(p) {
   });
 }
 
+// Resolves to the responder's pid (number), 'foreign-authwalled' for an
+// auth-gated monomind server, null for unreadable, or false for "no answer".
+function probePort(p) {
+  const http = require('http');
+  return new Promise((resolve) => {
+    const req = http.get({ hostname: 'localhost', port: p, path: '/api/status', timeout: 1000 }, (res) => {
+      let body = '';
+      res.on('data', (c) => { if (body.length < 4096) body += c; });
+      res.on('end', () => {
+        if (res.statusCode >= 500) return resolve(false);
+        try {
+          const parsed = JSON.parse(body);
+          if (typeof parsed.pid === 'number') return resolve(parsed.pid);
+          if (res.statusCode === 401 && parsed.error) return resolve('foreign-authwalled');
+          resolve(null);
+        } catch { resolve(null); }
+      });
+    });
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => { req.destroy(); resolve(false); });
+  });
+}
+
 const LOCK_FILE = path.join(CWD, '.monomind', 'control.lock');
 
 /**
@@ -142,6 +165,129 @@ function claimSpawnLock() {
 
 function releaseSpawnLock() {
   releaseLock(LOCK_FILE);
+}
+
+/**
+ * Confirms the spawned dashboard child actually bound a port, and updates
+ * control.json with the authoritative pid/port once it does.
+ *
+ * Runs in its own detached, fully independent process (see the
+ * MONOMIND_CONTROL_CONFIRM_MODE branch at the bottom of this file) — NOT
+ * inline inside the SessionStart-hook-invoked process. This can legitimately
+ * take up to HARD_CEILING_ATTEMPTS (~5 min: slow npx cold-resolve + AV/FS
+ * contention right after an install, #142) but the hook that spawns the
+ * dashboard is configured with a 5s timeout in settings.json — an inline
+ * await here would almost always get truncated by that hook timeout before
+ * ever reaching the slow paths #142/#143 were specifically added to
+ * tolerate, silently defeating those fixes and leaving control.json stuck on
+ * its pre-confirmation optimistic guess. Running this as a separate spawned
+ * process means the hook-invoked process can write the optimistic status and
+ * exit immediately (matching this file's own module docstring), while
+ * confirmation proceeds independently for as long as it legitimately needs.
+ */
+async function runConfirm({ childPid, port: defaultPort, boundReportPath, isNpxFallback }) {
+  const CONFIRM_ATTEMPTS = isNpxFallback ? 60 : 20; // 500ms/attempt: 30s vs 10s
+  const HARD_CEILING_ATTEMPTS = 600; // 500ms/attempt: 5 min — see doc comment above
+  let sawForeignOnDefault = false;
+  let attempt = 0;
+  for (; attempt < HARD_CEILING_ATTEMPTS; attempt++) {
+    await new Promise(r => setTimeout(r, 500));
+    // Past the minimum grace period, a dead child means it's not coming
+    // back — stop waiting immediately instead of burning the rest of the
+    // budget. A LIVE child that simply hasn't reported yet keeps getting the
+    // benefit of the doubt up to HARD_CEILING_ATTEMPTS instead of being
+    // killed on a fixed guess.
+    if (attempt >= CONFIRM_ATTEMPTS && !isPidAlive(childPid)) break;
+    // 1) Authoritative: child self-reported its bound port. Identity comes
+    // from boundReportPath's own per-invocation-unique path (nothing else on
+    // the machine knows it, since it's only handed to this child via env),
+    // NOT a pid match: under shell:true (#141's Windows EINVAL fix), childPid
+    // is the wrapping cmd.exe's pid, not the real server's — rep.pid !==
+    // childPid always, so a pid comparison here can never succeed on the
+    // npx-fallback path regardless of how long we wait (#143). rep.pid is
+    // the real server pid — use it for control.json.
+    try {
+      const rep = JSON.parse(fs.readFileSync(boundReportPath, 'utf8'));
+      if (rep && typeof rep.pid === 'number' && typeof rep.port === 'number') {
+        try { fs.unlinkSync(boundReportPath); } catch { /* ignore */ }
+        writeStatus(rep.pid, rep.port);
+        if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] server bound to port ${rep.port} (pid ${rep.pid})\n`);
+        return;
+      }
+    } catch { /* not written yet or old server — fall through to probe */ }
+    // 2) Fallback: pid-matched HTTP probe (old servers without report support)
+    for (let delta = 0; delta <= 10; delta++) {
+      const p = defaultPort + delta;
+      const responderPid = await probePort(p);
+      if (responderPid === false) continue;
+      if (responderPid === childPid) {
+        if (p !== defaultPort) {
+          writeStatus(childPid, p);
+          if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] server bound to port ${p} (updated control.json)\n`);
+        }
+        return;
+      }
+      if (p === defaultPort && (typeof responderPid === 'number' || responderPid === 'foreign-authwalled')) {
+        sawForeignOnDefault = true;
+      }
+      // pid mismatch or unreadable — not provably ours, keep scanning
+    }
+  }
+  try { fs.unlinkSync(boundReportPath); } catch { /* ignore */ }
+  if (sawForeignOnDefault) {
+    // Another project's server owns defaultPort and our child never proved
+    // its own port — point control.json at the live server instead of lying,
+    // and kill our redundant child.
+    try { process.kill(childPid, 'SIGTERM'); } catch { /* already gone */ }
+    if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] port ${defaultPort} is served by another project's control server — reusing it (killed redundant child)\n`);
+    let foreignPid = await probePort(defaultPort);
+    if (typeof foreignPid !== 'number' || foreignPid <= 0) {
+      try {
+        const { execFileSync } = require('child_process');
+        const lsofOut = execFileSync('lsof', ['-ti', `:${defaultPort}`, '-sTCP:LISTEN'], { encoding: 'utf8', timeout: 3000 }).trim();
+        const parsedPid = parseInt(lsofOut.split('\n')[0], 10);
+        if (Number.isInteger(parsedPid) && parsedPid > 0) foreignPid = parsedPid;
+      } catch { /* ignore */ }
+    }
+    writeStatus(typeof foreignPid === 'number' ? foreignPid : 0, defaultPort);
+    // Pair with the foreign server: resolve its project dir from its pid,
+    // copy its dashboard-token beside OUR control.json (ingest is
+    // default-deny — without this every event from this project 401s
+    // silently), and self-register in its known-projects so future token
+    // rotations propagate back here on server restart.
+    try {
+      if (typeof foreignPid === 'number' && foreignPid > 0) {
+        const { execFileSync } = require('child_process');
+        const out = execFileSync('lsof', ['-a', '-p', String(foreignPid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', timeout: 3000 });
+        const nLine = out.split('\n').find((l) => l.startsWith('n'));
+        const serverHome = nLine ? nLine.slice(1) : null;
+        if (serverHome) {
+          const srcTok = path.join(serverHome, '.monomind', 'dashboard-token');
+          const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
+          if (fs.existsSync(srcTok)) {
+            fs.copyFileSync(srcTok, dstTok);
+            fs.chmodSync(dstTok, 0o600);
+          }
+          const kpFile = path.join(serverHome, 'data', 'known-projects.json');
+          try {
+            const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
+            if (Array.isArray(kp) && !kp.includes(CWD)) {
+              kp.push(CWD);
+              fs.writeFileSync(kpFile, JSON.stringify(kp));
+            }
+          } catch { /* registry unreadable — token copy alone still unblocks events */ }
+          process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
+        }
+      }
+    } catch { /* pairing is best-effort; propagation-on-restart is the fallback */ }
+    return;
+  }
+  // Server never became reachable on any expected port — kill the child
+  // rather than leave an orphan bound to some port nothing will ever read.
+  // The next session-start simply retries.
+  try { process.kill(childPid, 'SIGTERM'); } catch { /* already gone */ }
+  try { fs.unlinkSync(STATUS_FILE); } catch { /* ignore */ }
+  process.stdout.write(`[control] server did not respond within ${((attempt + 1) * 500 / 1000).toFixed(1)} s — killed orphan, will retry next session\n`);
 }
 
 async function main() {
@@ -214,8 +360,8 @@ async function main() {
   // npx-fallback branch (cmd is 'npx'/'npx.cmd') pays npx's own first-time
   // package resolve into its `_npx` cache, measured at ~12s cold vs ~3s warm
   // (#142) — comfortably over the 10s budget every other branch needs.
+  // (Passed to the detached confirm process below — see runConfirm.)
   const isNpxFallback = cmd !== process.execPath;
-  const CONFIRM_ATTEMPTS = isNpxFallback ? 60 : 20; // 500ms/attempt: 30s vs 10s
 
   // The child writes its ACTUAL bound port here — the only identity-proof
   // signal. An HTTP probe alone can be answered by another project's server
@@ -246,153 +392,46 @@ async function main() {
   writeStatus(child.pid, DEFAULT_PORT);
   if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] started Neural Control Room on port ${DEFAULT_PORT} (pid ${child.pid})\n`);
 
-  // If port 4242 was in use, server.mjs auto-increments (up to +10).
-  // Poll a few ports to find where it actually bound and update control.json.
-  const http = require('http');
-  // Resolves to the responder's pid (number), 'foreign-authwalled' for an
-  // auth-gated monomind server, null for unreadable, or false for "no answer".
-  function probePort(p) {
-    return new Promise((resolve) => {
-      const req = http.get({ hostname: 'localhost', port: p, path: '/api/status', timeout: 1000 }, (res) => {
-        let body = '';
-        res.on('data', (c) => { if (body.length < 4096) body += c; });
-        res.on('end', () => {
-          if (res.statusCode >= 500) return resolve(false);
-          try {
-            const parsed = JSON.parse(body);
-            if (typeof parsed.pid === 'number') return resolve(parsed.pid);
-            if (res.statusCode === 401 && parsed.error) return resolve('foreign-authwalled');
-            resolve(null);
-          } catch { resolve(null); }
-        });
-      });
-      req.on('error', () => resolve(false));
-      req.on('timeout', () => { req.destroy(); resolve(false); });
-    });
-  }
+  // Hand off confirmation to a fully independent detached process instead of
+  // awaiting it inline (see runConfirm's doc comment for why: the hook that
+  // invokes THIS process has only a 5s timeout, far short of what
+  // confirmation can legitimately need). This process's job — spawn the
+  // dashboard and report the optimistic status — is done; exit immediately.
+  const confirmChild = spawn(process.execPath, [__filename], {
+    detached: true,
+    stdio: 'ignore',
+    cwd: CWD,
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: CWD,
+      MONOMIND_CONTROL_CONFIRM_MODE: '1',
+      MONOMIND_CONTROL_CONFIRM_PID: String(child.pid),
+      MONOMIND_CONTROL_CONFIRM_PORT: String(DEFAULT_PORT),
+      MONOMIND_CONTROL_CONFIRM_REPORT: BOUND_REPORT,
+      MONOMIND_CONTROL_CONFIRM_NPX: isNpxFallback ? '1' : '0',
+    },
+  });
+  confirmChild.unref();
 
-  // Give the server up to ~10 s to start, then confirm the actual port.
-  // Identity-first: the child's bound-report file (written by server.mjs) is
-  // authoritative; the HTTP probe only confirms a port when the responder's
-  // pid matches our child. A foreign server answering on DEFAULT_PORT must
-  // NOT be mistaken for ours — that lie misroutes every event emitter in
-  // this project (root cause of orgs running invisibly).
-  // Absolute safety net so a wedged-but-still-alive process can't hang this
-  // hook forever — CONFIRM_ATTEMPTS below is a minimum grace period, not a
-  // hard budget (#142 follow-up).
-  const HARD_CEILING_ATTEMPTS = 600; // 500ms/attempt: 5 min
-  async function confirmPort() {
-    let sawForeignOnDefault = false;
-    let attempt = 0;
-    for (; attempt < HARD_CEILING_ATTEMPTS; attempt++) {
-      await new Promise(r => setTimeout(r, 500));
-      // Past the minimum grace period, a dead child means it's not coming
-      // back — stop waiting immediately instead of burning the rest of the
-      // budget. A LIVE child that simply hasn't reported yet (npm/AV
-      // contention on a freshly-written node_modules right after install,
-      // measured once at ~142s vs the normal ~5-9s — #142 follow-up) keeps
-      // getting the benefit of the doubt up to HARD_CEILING_ATTEMPTS instead
-      // of being killed on a fixed guess.
-      if (attempt >= CONFIRM_ATTEMPTS && !isPidAlive(child.pid)) break;
-      // 1) Authoritative: child self-reported its bound port. Identity comes
-      // from BOUND_REPORT's own per-invocation-unique path (nothing else on
-      // the machine knows it, since it's only handed to this child via env),
-      // NOT a pid match: under shell:true (#141's Windows EINVAL fix),
-      // child.pid is the wrapping cmd.exe's pid, not the real server's —
-      // rep.pid !== child.pid always, so a pid comparison here can never
-      // succeed on the npx-fallback path regardless of how long we wait
-      // (#143). rep.pid is the real server pid — use it for control.json.
-      try {
-        const rep = JSON.parse(fs.readFileSync(BOUND_REPORT, 'utf8'));
-        if (rep && typeof rep.pid === 'number' && typeof rep.port === 'number') {
-          try { fs.unlinkSync(BOUND_REPORT); } catch { /* ignore */ }
-          writeStatus(rep.pid, rep.port);
-          if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] server bound to port ${rep.port} (pid ${rep.pid})\n`);
-          return;
-        }
-      } catch { /* not written yet or old server — fall through to probe */ }
-      // 2) Fallback: pid-matched HTTP probe (old servers without report support)
-      for (let delta = 0; delta <= 10; delta++) {
-        const p = DEFAULT_PORT + delta;
-        const responderPid = await probePort(p);
-        if (responderPid === false) continue;
-        if (responderPid === child.pid) {
-          if (p !== DEFAULT_PORT) {
-            writeStatus(child.pid, p);
-            if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] server bound to port ${p} (updated control.json)\n`);
-          }
-          return;
-        }
-        if (p === DEFAULT_PORT && (typeof responderPid === 'number' || responderPid === 'foreign-authwalled')) {
-          sawForeignOnDefault = true;
-        }
-        // pid mismatch or unreadable — not provably ours, keep scanning
-      }
-    }
-    try { fs.unlinkSync(BOUND_REPORT); } catch { /* ignore */ }
-    if (sawForeignOnDefault) {
-      // Another project's server owns DEFAULT_PORT and our child never proved
-      // its own port — point control.json at the live server instead of lying,
-      // and kill our redundant child.
-      try { process.kill(child.pid, 'SIGTERM'); } catch { /* already gone */ }
-      if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] port ${DEFAULT_PORT} is served by another project's control server — reusing it (killed redundant child)\n`);
-      let foreignPid = await probePort(DEFAULT_PORT);
-      if (typeof foreignPid !== 'number' || foreignPid <= 0) {
-        try {
-          const { execFileSync } = require('child_process');
-          const lsofOut = execFileSync('lsof', ['-ti', `:${DEFAULT_PORT}`, '-sTCP:LISTEN'], { encoding: 'utf8', timeout: 3000 }).trim();
-          const parsedPid = parseInt(lsofOut.split('\n')[0], 10);
-          if (Number.isInteger(parsedPid) && parsedPid > 0) foreignPid = parsedPid;
-        } catch { /* ignore */ }
-      }
-      writeStatus(typeof foreignPid === 'number' ? foreignPid : 0, DEFAULT_PORT);
-      // Pair with the foreign server: resolve its project dir from its pid,
-      // copy its dashboard-token beside OUR control.json (ingest is
-      // default-deny — without this every event from this project 401s
-      // silently), and self-register in its known-projects so future token
-      // rotations propagate back here on server restart.
-      try {
-        if (typeof foreignPid === 'number' && foreignPid > 0) {
-          const { execFileSync } = require('child_process');
-          const out = execFileSync('lsof', ['-a', '-p', String(foreignPid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', timeout: 3000 });
-          const nLine = out.split('\n').find((l) => l.startsWith('n'));
-          const serverHome = nLine ? nLine.slice(1) : null;
-          if (serverHome) {
-            const srcTok = path.join(serverHome, '.monomind', 'dashboard-token');
-            const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
-            if (fs.existsSync(srcTok)) {
-              fs.copyFileSync(srcTok, dstTok);
-              fs.chmodSync(dstTok, 0o600);
-            }
-            const kpFile = path.join(serverHome, 'data', 'known-projects.json');
-            try {
-              const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
-              if (Array.isArray(kp) && !kp.includes(CWD)) {
-                kp.push(CWD);
-                fs.writeFileSync(kpFile, JSON.stringify(kp));
-              }
-            } catch { /* registry unreadable — token copy alone still unblocks events */ }
-            process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
-          }
-        }
-      } catch { /* pairing is best-effort; propagation-on-restart is the fallback */ }
-      return;
-    }
-    // Server never became reachable on any expected port — kill the child
-    // rather than leave an orphan bound to some port nothing will ever read.
-    // The next session-start simply retries.
-    try { process.kill(child.pid, 'SIGTERM'); } catch { /* already gone */ }
-    try { fs.unlinkSync(STATUS_FILE); } catch { /* ignore */ }
-    process.stdout.write(`[control] server did not respond within ${((attempt + 1) * 500 / 1000).toFixed(1)} s — killed orphan, will retry next session\n`);
-  }
-
-  confirmPort().catch(() => {}).finally(() => { releaseSpawnLock(); process.exit(0); });
-}
-
-main().catch((err) => {
-  if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") {
-    process.stderr.write(`[control] failed to start: ${err && err.message ? err.message : err}\n`);
-  }
   releaseSpawnLock();
   process.exit(0);
-});
+}
+
+if (String(process.env.MONOMIND_CONTROL_CONFIRM_MODE || '') === '1') {
+  // Standalone confirmation process spawned by main() above — see runConfirm's
+  // doc comment. Not itself subject to the SessionStart hook's 5s timeout.
+  runConfirm({
+    childPid: Number(process.env.MONOMIND_CONTROL_CONFIRM_PID),
+    port: Number(process.env.MONOMIND_CONTROL_CONFIRM_PORT) || DEFAULT_PORT,
+    boundReportPath: process.env.MONOMIND_CONTROL_CONFIRM_REPORT,
+    isNpxFallback: process.env.MONOMIND_CONTROL_CONFIRM_NPX === '1',
+  }).catch(() => {}).finally(() => process.exit(0));
+} else {
+  main().catch((err) => {
+    if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") {
+      process.stderr.write(`[control] failed to start: ${err && err.message ? err.message : err}\n`);
+    }
+    releaseSpawnLock();
+    process.exit(0);
+  });
+}

--- a/.gemini/helpers/control-start.cjs
+++ b/.gemini/helpers/control-start.cjs
@@ -119,6 +119,29 @@ function probeStatus(p) {
   });
 }
 
+// Resolves to the responder's pid (number), 'foreign-authwalled' for an
+// auth-gated monomind server, null for unreadable, or false for "no answer".
+function probePort(p) {
+  const http = require('http');
+  return new Promise((resolve) => {
+    const req = http.get({ hostname: 'localhost', port: p, path: '/api/status', timeout: 1000 }, (res) => {
+      let body = '';
+      res.on('data', (c) => { if (body.length < 4096) body += c; });
+      res.on('end', () => {
+        if (res.statusCode >= 500) return resolve(false);
+        try {
+          const parsed = JSON.parse(body);
+          if (typeof parsed.pid === 'number') return resolve(parsed.pid);
+          if (res.statusCode === 401 && parsed.error) return resolve('foreign-authwalled');
+          resolve(null);
+        } catch { resolve(null); }
+      });
+    });
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => { req.destroy(); resolve(false); });
+  });
+}
+
 const LOCK_FILE = path.join(CWD, '.monomind', 'control.lock');
 
 /**
@@ -142,6 +165,129 @@ function claimSpawnLock() {
 
 function releaseSpawnLock() {
   releaseLock(LOCK_FILE);
+}
+
+/**
+ * Confirms the spawned dashboard child actually bound a port, and updates
+ * control.json with the authoritative pid/port once it does.
+ *
+ * Runs in its own detached, fully independent process (see the
+ * MONOMIND_CONTROL_CONFIRM_MODE branch at the bottom of this file) — NOT
+ * inline inside the SessionStart-hook-invoked process. This can legitimately
+ * take up to HARD_CEILING_ATTEMPTS (~5 min: slow npx cold-resolve + AV/FS
+ * contention right after an install, #142) but the hook that spawns the
+ * dashboard is configured with a 5s timeout in settings.json — an inline
+ * await here would almost always get truncated by that hook timeout before
+ * ever reaching the slow paths #142/#143 were specifically added to
+ * tolerate, silently defeating those fixes and leaving control.json stuck on
+ * its pre-confirmation optimistic guess. Running this as a separate spawned
+ * process means the hook-invoked process can write the optimistic status and
+ * exit immediately (matching this file's own module docstring), while
+ * confirmation proceeds independently for as long as it legitimately needs.
+ */
+async function runConfirm({ childPid, port: defaultPort, boundReportPath, isNpxFallback }) {
+  const CONFIRM_ATTEMPTS = isNpxFallback ? 60 : 20; // 500ms/attempt: 30s vs 10s
+  const HARD_CEILING_ATTEMPTS = 600; // 500ms/attempt: 5 min — see doc comment above
+  let sawForeignOnDefault = false;
+  let attempt = 0;
+  for (; attempt < HARD_CEILING_ATTEMPTS; attempt++) {
+    await new Promise(r => setTimeout(r, 500));
+    // Past the minimum grace period, a dead child means it's not coming
+    // back — stop waiting immediately instead of burning the rest of the
+    // budget. A LIVE child that simply hasn't reported yet keeps getting the
+    // benefit of the doubt up to HARD_CEILING_ATTEMPTS instead of being
+    // killed on a fixed guess.
+    if (attempt >= CONFIRM_ATTEMPTS && !isPidAlive(childPid)) break;
+    // 1) Authoritative: child self-reported its bound port. Identity comes
+    // from boundReportPath's own per-invocation-unique path (nothing else on
+    // the machine knows it, since it's only handed to this child via env),
+    // NOT a pid match: under shell:true (#141's Windows EINVAL fix), childPid
+    // is the wrapping cmd.exe's pid, not the real server's — rep.pid !==
+    // childPid always, so a pid comparison here can never succeed on the
+    // npx-fallback path regardless of how long we wait (#143). rep.pid is
+    // the real server pid — use it for control.json.
+    try {
+      const rep = JSON.parse(fs.readFileSync(boundReportPath, 'utf8'));
+      if (rep && typeof rep.pid === 'number' && typeof rep.port === 'number') {
+        try { fs.unlinkSync(boundReportPath); } catch { /* ignore */ }
+        writeStatus(rep.pid, rep.port);
+        if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] server bound to port ${rep.port} (pid ${rep.pid})\n`);
+        return;
+      }
+    } catch { /* not written yet or old server — fall through to probe */ }
+    // 2) Fallback: pid-matched HTTP probe (old servers without report support)
+    for (let delta = 0; delta <= 10; delta++) {
+      const p = defaultPort + delta;
+      const responderPid = await probePort(p);
+      if (responderPid === false) continue;
+      if (responderPid === childPid) {
+        if (p !== defaultPort) {
+          writeStatus(childPid, p);
+          if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] server bound to port ${p} (updated control.json)\n`);
+        }
+        return;
+      }
+      if (p === defaultPort && (typeof responderPid === 'number' || responderPid === 'foreign-authwalled')) {
+        sawForeignOnDefault = true;
+      }
+      // pid mismatch or unreadable — not provably ours, keep scanning
+    }
+  }
+  try { fs.unlinkSync(boundReportPath); } catch { /* ignore */ }
+  if (sawForeignOnDefault) {
+    // Another project's server owns defaultPort and our child never proved
+    // its own port — point control.json at the live server instead of lying,
+    // and kill our redundant child.
+    try { process.kill(childPid, 'SIGTERM'); } catch { /* already gone */ }
+    if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] port ${defaultPort} is served by another project's control server — reusing it (killed redundant child)\n`);
+    let foreignPid = await probePort(defaultPort);
+    if (typeof foreignPid !== 'number' || foreignPid <= 0) {
+      try {
+        const { execFileSync } = require('child_process');
+        const lsofOut = execFileSync('lsof', ['-ti', `:${defaultPort}`, '-sTCP:LISTEN'], { encoding: 'utf8', timeout: 3000 }).trim();
+        const parsedPid = parseInt(lsofOut.split('\n')[0], 10);
+        if (Number.isInteger(parsedPid) && parsedPid > 0) foreignPid = parsedPid;
+      } catch { /* ignore */ }
+    }
+    writeStatus(typeof foreignPid === 'number' ? foreignPid : 0, defaultPort);
+    // Pair with the foreign server: resolve its project dir from its pid,
+    // copy its dashboard-token beside OUR control.json (ingest is
+    // default-deny — without this every event from this project 401s
+    // silently), and self-register in its known-projects so future token
+    // rotations propagate back here on server restart.
+    try {
+      if (typeof foreignPid === 'number' && foreignPid > 0) {
+        const { execFileSync } = require('child_process');
+        const out = execFileSync('lsof', ['-a', '-p', String(foreignPid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', timeout: 3000 });
+        const nLine = out.split('\n').find((l) => l.startsWith('n'));
+        const serverHome = nLine ? nLine.slice(1) : null;
+        if (serverHome) {
+          const srcTok = path.join(serverHome, '.monomind', 'dashboard-token');
+          const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
+          if (fs.existsSync(srcTok)) {
+            fs.copyFileSync(srcTok, dstTok);
+            fs.chmodSync(dstTok, 0o600);
+          }
+          const kpFile = path.join(serverHome, 'data', 'known-projects.json');
+          try {
+            const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
+            if (Array.isArray(kp) && !kp.includes(CWD)) {
+              kp.push(CWD);
+              fs.writeFileSync(kpFile, JSON.stringify(kp));
+            }
+          } catch { /* registry unreadable — token copy alone still unblocks events */ }
+          process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
+        }
+      }
+    } catch { /* pairing is best-effort; propagation-on-restart is the fallback */ }
+    return;
+  }
+  // Server never became reachable on any expected port — kill the child
+  // rather than leave an orphan bound to some port nothing will ever read.
+  // The next session-start simply retries.
+  try { process.kill(childPid, 'SIGTERM'); } catch { /* already gone */ }
+  try { fs.unlinkSync(STATUS_FILE); } catch { /* ignore */ }
+  process.stdout.write(`[control] server did not respond within ${((attempt + 1) * 500 / 1000).toFixed(1)} s — killed orphan, will retry next session\n`);
 }
 
 async function main() {
@@ -214,8 +360,8 @@ async function main() {
   // npx-fallback branch (cmd is 'npx'/'npx.cmd') pays npx's own first-time
   // package resolve into its `_npx` cache, measured at ~12s cold vs ~3s warm
   // (#142) — comfortably over the 10s budget every other branch needs.
+  // (Passed to the detached confirm process below — see runConfirm.)
   const isNpxFallback = cmd !== process.execPath;
-  const CONFIRM_ATTEMPTS = isNpxFallback ? 60 : 20; // 500ms/attempt: 30s vs 10s
 
   // The child writes its ACTUAL bound port here — the only identity-proof
   // signal. An HTTP probe alone can be answered by another project's server
@@ -246,153 +392,46 @@ async function main() {
   writeStatus(child.pid, DEFAULT_PORT);
   if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] started Neural Control Room on port ${DEFAULT_PORT} (pid ${child.pid})\n`);
 
-  // If port 4242 was in use, server.mjs auto-increments (up to +10).
-  // Poll a few ports to find where it actually bound and update control.json.
-  const http = require('http');
-  // Resolves to the responder's pid (number), 'foreign-authwalled' for an
-  // auth-gated monomind server, null for unreadable, or false for "no answer".
-  function probePort(p) {
-    return new Promise((resolve) => {
-      const req = http.get({ hostname: 'localhost', port: p, path: '/api/status', timeout: 1000 }, (res) => {
-        let body = '';
-        res.on('data', (c) => { if (body.length < 4096) body += c; });
-        res.on('end', () => {
-          if (res.statusCode >= 500) return resolve(false);
-          try {
-            const parsed = JSON.parse(body);
-            if (typeof parsed.pid === 'number') return resolve(parsed.pid);
-            if (res.statusCode === 401 && parsed.error) return resolve('foreign-authwalled');
-            resolve(null);
-          } catch { resolve(null); }
-        });
-      });
-      req.on('error', () => resolve(false));
-      req.on('timeout', () => { req.destroy(); resolve(false); });
-    });
-  }
+  // Hand off confirmation to a fully independent detached process instead of
+  // awaiting it inline (see runConfirm's doc comment for why: the hook that
+  // invokes THIS process has only a 5s timeout, far short of what
+  // confirmation can legitimately need). This process's job — spawn the
+  // dashboard and report the optimistic status — is done; exit immediately.
+  const confirmChild = spawn(process.execPath, [__filename], {
+    detached: true,
+    stdio: 'ignore',
+    cwd: CWD,
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: CWD,
+      MONOMIND_CONTROL_CONFIRM_MODE: '1',
+      MONOMIND_CONTROL_CONFIRM_PID: String(child.pid),
+      MONOMIND_CONTROL_CONFIRM_PORT: String(DEFAULT_PORT),
+      MONOMIND_CONTROL_CONFIRM_REPORT: BOUND_REPORT,
+      MONOMIND_CONTROL_CONFIRM_NPX: isNpxFallback ? '1' : '0',
+    },
+  });
+  confirmChild.unref();
 
-  // Give the server up to ~10 s to start, then confirm the actual port.
-  // Identity-first: the child's bound-report file (written by server.mjs) is
-  // authoritative; the HTTP probe only confirms a port when the responder's
-  // pid matches our child. A foreign server answering on DEFAULT_PORT must
-  // NOT be mistaken for ours — that lie misroutes every event emitter in
-  // this project (root cause of orgs running invisibly).
-  // Absolute safety net so a wedged-but-still-alive process can't hang this
-  // hook forever — CONFIRM_ATTEMPTS below is a minimum grace period, not a
-  // hard budget (#142 follow-up).
-  const HARD_CEILING_ATTEMPTS = 600; // 500ms/attempt: 5 min
-  async function confirmPort() {
-    let sawForeignOnDefault = false;
-    let attempt = 0;
-    for (; attempt < HARD_CEILING_ATTEMPTS; attempt++) {
-      await new Promise(r => setTimeout(r, 500));
-      // Past the minimum grace period, a dead child means it's not coming
-      // back — stop waiting immediately instead of burning the rest of the
-      // budget. A LIVE child that simply hasn't reported yet (npm/AV
-      // contention on a freshly-written node_modules right after install,
-      // measured once at ~142s vs the normal ~5-9s — #142 follow-up) keeps
-      // getting the benefit of the doubt up to HARD_CEILING_ATTEMPTS instead
-      // of being killed on a fixed guess.
-      if (attempt >= CONFIRM_ATTEMPTS && !isPidAlive(child.pid)) break;
-      // 1) Authoritative: child self-reported its bound port. Identity comes
-      // from BOUND_REPORT's own per-invocation-unique path (nothing else on
-      // the machine knows it, since it's only handed to this child via env),
-      // NOT a pid match: under shell:true (#141's Windows EINVAL fix),
-      // child.pid is the wrapping cmd.exe's pid, not the real server's —
-      // rep.pid !== child.pid always, so a pid comparison here can never
-      // succeed on the npx-fallback path regardless of how long we wait
-      // (#143). rep.pid is the real server pid — use it for control.json.
-      try {
-        const rep = JSON.parse(fs.readFileSync(BOUND_REPORT, 'utf8'));
-        if (rep && typeof rep.pid === 'number' && typeof rep.port === 'number') {
-          try { fs.unlinkSync(BOUND_REPORT); } catch { /* ignore */ }
-          writeStatus(rep.pid, rep.port);
-          if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] server bound to port ${rep.port} (pid ${rep.pid})\n`);
-          return;
-        }
-      } catch { /* not written yet or old server — fall through to probe */ }
-      // 2) Fallback: pid-matched HTTP probe (old servers without report support)
-      for (let delta = 0; delta <= 10; delta++) {
-        const p = DEFAULT_PORT + delta;
-        const responderPid = await probePort(p);
-        if (responderPid === false) continue;
-        if (responderPid === child.pid) {
-          if (p !== DEFAULT_PORT) {
-            writeStatus(child.pid, p);
-            if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] server bound to port ${p} (updated control.json)\n`);
-          }
-          return;
-        }
-        if (p === DEFAULT_PORT && (typeof responderPid === 'number' || responderPid === 'foreign-authwalled')) {
-          sawForeignOnDefault = true;
-        }
-        // pid mismatch or unreadable — not provably ours, keep scanning
-      }
-    }
-    try { fs.unlinkSync(BOUND_REPORT); } catch { /* ignore */ }
-    if (sawForeignOnDefault) {
-      // Another project's server owns DEFAULT_PORT and our child never proved
-      // its own port — point control.json at the live server instead of lying,
-      // and kill our redundant child.
-      try { process.kill(child.pid, 'SIGTERM'); } catch { /* already gone */ }
-      if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] port ${DEFAULT_PORT} is served by another project's control server — reusing it (killed redundant child)\n`);
-      let foreignPid = await probePort(DEFAULT_PORT);
-      if (typeof foreignPid !== 'number' || foreignPid <= 0) {
-        try {
-          const { execFileSync } = require('child_process');
-          const lsofOut = execFileSync('lsof', ['-ti', `:${DEFAULT_PORT}`, '-sTCP:LISTEN'], { encoding: 'utf8', timeout: 3000 }).trim();
-          const parsedPid = parseInt(lsofOut.split('\n')[0], 10);
-          if (Number.isInteger(parsedPid) && parsedPid > 0) foreignPid = parsedPid;
-        } catch { /* ignore */ }
-      }
-      writeStatus(typeof foreignPid === 'number' ? foreignPid : 0, DEFAULT_PORT);
-      // Pair with the foreign server: resolve its project dir from its pid,
-      // copy its dashboard-token beside OUR control.json (ingest is
-      // default-deny — without this every event from this project 401s
-      // silently), and self-register in its known-projects so future token
-      // rotations propagate back here on server restart.
-      try {
-        if (typeof foreignPid === 'number' && foreignPid > 0) {
-          const { execFileSync } = require('child_process');
-          const out = execFileSync('lsof', ['-a', '-p', String(foreignPid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', timeout: 3000 });
-          const nLine = out.split('\n').find((l) => l.startsWith('n'));
-          const serverHome = nLine ? nLine.slice(1) : null;
-          if (serverHome) {
-            const srcTok = path.join(serverHome, '.monomind', 'dashboard-token');
-            const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
-            if (fs.existsSync(srcTok)) {
-              fs.copyFileSync(srcTok, dstTok);
-              fs.chmodSync(dstTok, 0o600);
-            }
-            const kpFile = path.join(serverHome, 'data', 'known-projects.json');
-            try {
-              const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
-              if (Array.isArray(kp) && !kp.includes(CWD)) {
-                kp.push(CWD);
-                fs.writeFileSync(kpFile, JSON.stringify(kp));
-              }
-            } catch { /* registry unreadable — token copy alone still unblocks events */ }
-            process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
-          }
-        }
-      } catch { /* pairing is best-effort; propagation-on-restart is the fallback */ }
-      return;
-    }
-    // Server never became reachable on any expected port — kill the child
-    // rather than leave an orphan bound to some port nothing will ever read.
-    // The next session-start simply retries.
-    try { process.kill(child.pid, 'SIGTERM'); } catch { /* already gone */ }
-    try { fs.unlinkSync(STATUS_FILE); } catch { /* ignore */ }
-    process.stdout.write(`[control] server did not respond within ${((attempt + 1) * 500 / 1000).toFixed(1)} s — killed orphan, will retry next session\n`);
-  }
-
-  confirmPort().catch(() => {}).finally(() => { releaseSpawnLock(); process.exit(0); });
-}
-
-main().catch((err) => {
-  if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") {
-    process.stderr.write(`[control] failed to start: ${err && err.message ? err.message : err}\n`);
-  }
   releaseSpawnLock();
   process.exit(0);
-});
+}
+
+if (String(process.env.MONOMIND_CONTROL_CONFIRM_MODE || '') === '1') {
+  // Standalone confirmation process spawned by main() above — see runConfirm's
+  // doc comment. Not itself subject to the SessionStart hook's 5s timeout.
+  runConfirm({
+    childPid: Number(process.env.MONOMIND_CONTROL_CONFIRM_PID),
+    port: Number(process.env.MONOMIND_CONTROL_CONFIRM_PORT) || DEFAULT_PORT,
+    boundReportPath: process.env.MONOMIND_CONTROL_CONFIRM_REPORT,
+    isNpxFallback: process.env.MONOMIND_CONTROL_CONFIRM_NPX === '1',
+  }).catch(() => {}).finally(() => process.exit(0));
+} else {
+  main().catch((err) => {
+    if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") {
+      process.stderr.write(`[control] failed to start: ${err && err.message ? err.message : err}\n`);
+    }
+    releaseSpawnLock();
+    process.exit(0);
+  });
+}

--- a/packages/@monomind/cli/.claude/helpers/control-start.cjs
+++ b/packages/@monomind/cli/.claude/helpers/control-start.cjs
@@ -119,6 +119,29 @@ function probeStatus(p) {
   });
 }
 
+// Resolves to the responder's pid (number), 'foreign-authwalled' for an
+// auth-gated monomind server, null for unreadable, or false for "no answer".
+function probePort(p) {
+  const http = require('http');
+  return new Promise((resolve) => {
+    const req = http.get({ hostname: 'localhost', port: p, path: '/api/status', timeout: 1000 }, (res) => {
+      let body = '';
+      res.on('data', (c) => { if (body.length < 4096) body += c; });
+      res.on('end', () => {
+        if (res.statusCode >= 500) return resolve(false);
+        try {
+          const parsed = JSON.parse(body);
+          if (typeof parsed.pid === 'number') return resolve(parsed.pid);
+          if (res.statusCode === 401 && parsed.error) return resolve('foreign-authwalled');
+          resolve(null);
+        } catch { resolve(null); }
+      });
+    });
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => { req.destroy(); resolve(false); });
+  });
+}
+
 const LOCK_FILE = path.join(CWD, '.monomind', 'control.lock');
 
 /**
@@ -142,6 +165,129 @@ function claimSpawnLock() {
 
 function releaseSpawnLock() {
   releaseLock(LOCK_FILE);
+}
+
+/**
+ * Confirms the spawned dashboard child actually bound a port, and updates
+ * control.json with the authoritative pid/port once it does.
+ *
+ * Runs in its own detached, fully independent process (see the
+ * MONOMIND_CONTROL_CONFIRM_MODE branch at the bottom of this file) — NOT
+ * inline inside the SessionStart-hook-invoked process. This can legitimately
+ * take up to HARD_CEILING_ATTEMPTS (~5 min: slow npx cold-resolve + AV/FS
+ * contention right after an install, #142) but the hook that spawns the
+ * dashboard is configured with a 5s timeout in settings.json — an inline
+ * await here would almost always get truncated by that hook timeout before
+ * ever reaching the slow paths #142/#143 were specifically added to
+ * tolerate, silently defeating those fixes and leaving control.json stuck on
+ * its pre-confirmation optimistic guess. Running this as a separate spawned
+ * process means the hook-invoked process can write the optimistic status and
+ * exit immediately (matching this file's own module docstring), while
+ * confirmation proceeds independently for as long as it legitimately needs.
+ */
+async function runConfirm({ childPid, port: defaultPort, boundReportPath, isNpxFallback }) {
+  const CONFIRM_ATTEMPTS = isNpxFallback ? 60 : 20; // 500ms/attempt: 30s vs 10s
+  const HARD_CEILING_ATTEMPTS = 600; // 500ms/attempt: 5 min — see doc comment above
+  let sawForeignOnDefault = false;
+  let attempt = 0;
+  for (; attempt < HARD_CEILING_ATTEMPTS; attempt++) {
+    await new Promise(r => setTimeout(r, 500));
+    // Past the minimum grace period, a dead child means it's not coming
+    // back — stop waiting immediately instead of burning the rest of the
+    // budget. A LIVE child that simply hasn't reported yet keeps getting the
+    // benefit of the doubt up to HARD_CEILING_ATTEMPTS instead of being
+    // killed on a fixed guess.
+    if (attempt >= CONFIRM_ATTEMPTS && !isPidAlive(childPid)) break;
+    // 1) Authoritative: child self-reported its bound port. Identity comes
+    // from boundReportPath's own per-invocation-unique path (nothing else on
+    // the machine knows it, since it's only handed to this child via env),
+    // NOT a pid match: under shell:true (#141's Windows EINVAL fix), childPid
+    // is the wrapping cmd.exe's pid, not the real server's — rep.pid !==
+    // childPid always, so a pid comparison here can never succeed on the
+    // npx-fallback path regardless of how long we wait (#143). rep.pid is
+    // the real server pid — use it for control.json.
+    try {
+      const rep = JSON.parse(fs.readFileSync(boundReportPath, 'utf8'));
+      if (rep && typeof rep.pid === 'number' && typeof rep.port === 'number') {
+        try { fs.unlinkSync(boundReportPath); } catch { /* ignore */ }
+        writeStatus(rep.pid, rep.port);
+        if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] server bound to port ${rep.port} (pid ${rep.pid})\n`);
+        return;
+      }
+    } catch { /* not written yet or old server — fall through to probe */ }
+    // 2) Fallback: pid-matched HTTP probe (old servers without report support)
+    for (let delta = 0; delta <= 10; delta++) {
+      const p = defaultPort + delta;
+      const responderPid = await probePort(p);
+      if (responderPid === false) continue;
+      if (responderPid === childPid) {
+        if (p !== defaultPort) {
+          writeStatus(childPid, p);
+          if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] server bound to port ${p} (updated control.json)\n`);
+        }
+        return;
+      }
+      if (p === defaultPort && (typeof responderPid === 'number' || responderPid === 'foreign-authwalled')) {
+        sawForeignOnDefault = true;
+      }
+      // pid mismatch or unreadable — not provably ours, keep scanning
+    }
+  }
+  try { fs.unlinkSync(boundReportPath); } catch { /* ignore */ }
+  if (sawForeignOnDefault) {
+    // Another project's server owns defaultPort and our child never proved
+    // its own port — point control.json at the live server instead of lying,
+    // and kill our redundant child.
+    try { process.kill(childPid, 'SIGTERM'); } catch { /* already gone */ }
+    if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] port ${defaultPort} is served by another project's control server — reusing it (killed redundant child)\n`);
+    let foreignPid = await probePort(defaultPort);
+    if (typeof foreignPid !== 'number' || foreignPid <= 0) {
+      try {
+        const { execFileSync } = require('child_process');
+        const lsofOut = execFileSync('lsof', ['-ti', `:${defaultPort}`, '-sTCP:LISTEN'], { encoding: 'utf8', timeout: 3000 }).trim();
+        const parsedPid = parseInt(lsofOut.split('\n')[0], 10);
+        if (Number.isInteger(parsedPid) && parsedPid > 0) foreignPid = parsedPid;
+      } catch { /* ignore */ }
+    }
+    writeStatus(typeof foreignPid === 'number' ? foreignPid : 0, defaultPort);
+    // Pair with the foreign server: resolve its project dir from its pid,
+    // copy its dashboard-token beside OUR control.json (ingest is
+    // default-deny — without this every event from this project 401s
+    // silently), and self-register in its known-projects so future token
+    // rotations propagate back here on server restart.
+    try {
+      if (typeof foreignPid === 'number' && foreignPid > 0) {
+        const { execFileSync } = require('child_process');
+        const out = execFileSync('lsof', ['-a', '-p', String(foreignPid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', timeout: 3000 });
+        const nLine = out.split('\n').find((l) => l.startsWith('n'));
+        const serverHome = nLine ? nLine.slice(1) : null;
+        if (serverHome) {
+          const srcTok = path.join(serverHome, '.monomind', 'dashboard-token');
+          const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
+          if (fs.existsSync(srcTok)) {
+            fs.copyFileSync(srcTok, dstTok);
+            fs.chmodSync(dstTok, 0o600);
+          }
+          const kpFile = path.join(serverHome, 'data', 'known-projects.json');
+          try {
+            const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
+            if (Array.isArray(kp) && !kp.includes(CWD)) {
+              kp.push(CWD);
+              fs.writeFileSync(kpFile, JSON.stringify(kp));
+            }
+          } catch { /* registry unreadable — token copy alone still unblocks events */ }
+          process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
+        }
+      }
+    } catch { /* pairing is best-effort; propagation-on-restart is the fallback */ }
+    return;
+  }
+  // Server never became reachable on any expected port — kill the child
+  // rather than leave an orphan bound to some port nothing will ever read.
+  // The next session-start simply retries.
+  try { process.kill(childPid, 'SIGTERM'); } catch { /* already gone */ }
+  try { fs.unlinkSync(STATUS_FILE); } catch { /* ignore */ }
+  process.stdout.write(`[control] server did not respond within ${((attempt + 1) * 500 / 1000).toFixed(1)} s — killed orphan, will retry next session\n`);
 }
 
 async function main() {
@@ -214,8 +360,8 @@ async function main() {
   // npx-fallback branch (cmd is 'npx'/'npx.cmd') pays npx's own first-time
   // package resolve into its `_npx` cache, measured at ~12s cold vs ~3s warm
   // (#142) — comfortably over the 10s budget every other branch needs.
+  // (Passed to the detached confirm process below — see runConfirm.)
   const isNpxFallback = cmd !== process.execPath;
-  const CONFIRM_ATTEMPTS = isNpxFallback ? 60 : 20; // 500ms/attempt: 30s vs 10s
 
   // The child writes its ACTUAL bound port here — the only identity-proof
   // signal. An HTTP probe alone can be answered by another project's server
@@ -246,153 +392,46 @@ async function main() {
   writeStatus(child.pid, DEFAULT_PORT);
   if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] started Neural Control Room on port ${DEFAULT_PORT} (pid ${child.pid})\n`);
 
-  // If port 4242 was in use, server.mjs auto-increments (up to +10).
-  // Poll a few ports to find where it actually bound and update control.json.
-  const http = require('http');
-  // Resolves to the responder's pid (number), 'foreign-authwalled' for an
-  // auth-gated monomind server, null for unreadable, or false for "no answer".
-  function probePort(p) {
-    return new Promise((resolve) => {
-      const req = http.get({ hostname: 'localhost', port: p, path: '/api/status', timeout: 1000 }, (res) => {
-        let body = '';
-        res.on('data', (c) => { if (body.length < 4096) body += c; });
-        res.on('end', () => {
-          if (res.statusCode >= 500) return resolve(false);
-          try {
-            const parsed = JSON.parse(body);
-            if (typeof parsed.pid === 'number') return resolve(parsed.pid);
-            if (res.statusCode === 401 && parsed.error) return resolve('foreign-authwalled');
-            resolve(null);
-          } catch { resolve(null); }
-        });
-      });
-      req.on('error', () => resolve(false));
-      req.on('timeout', () => { req.destroy(); resolve(false); });
-    });
-  }
+  // Hand off confirmation to a fully independent detached process instead of
+  // awaiting it inline (see runConfirm's doc comment for why: the hook that
+  // invokes THIS process has only a 5s timeout, far short of what
+  // confirmation can legitimately need). This process's job — spawn the
+  // dashboard and report the optimistic status — is done; exit immediately.
+  const confirmChild = spawn(process.execPath, [__filename], {
+    detached: true,
+    stdio: 'ignore',
+    cwd: CWD,
+    env: {
+      ...process.env,
+      CLAUDE_PROJECT_DIR: CWD,
+      MONOMIND_CONTROL_CONFIRM_MODE: '1',
+      MONOMIND_CONTROL_CONFIRM_PID: String(child.pid),
+      MONOMIND_CONTROL_CONFIRM_PORT: String(DEFAULT_PORT),
+      MONOMIND_CONTROL_CONFIRM_REPORT: BOUND_REPORT,
+      MONOMIND_CONTROL_CONFIRM_NPX: isNpxFallback ? '1' : '0',
+    },
+  });
+  confirmChild.unref();
 
-  // Give the server up to ~10 s to start, then confirm the actual port.
-  // Identity-first: the child's bound-report file (written by server.mjs) is
-  // authoritative; the HTTP probe only confirms a port when the responder's
-  // pid matches our child. A foreign server answering on DEFAULT_PORT must
-  // NOT be mistaken for ours — that lie misroutes every event emitter in
-  // this project (root cause of orgs running invisibly).
-  // Absolute safety net so a wedged-but-still-alive process can't hang this
-  // hook forever — CONFIRM_ATTEMPTS below is a minimum grace period, not a
-  // hard budget (#142 follow-up).
-  const HARD_CEILING_ATTEMPTS = 600; // 500ms/attempt: 5 min
-  async function confirmPort() {
-    let sawForeignOnDefault = false;
-    let attempt = 0;
-    for (; attempt < HARD_CEILING_ATTEMPTS; attempt++) {
-      await new Promise(r => setTimeout(r, 500));
-      // Past the minimum grace period, a dead child means it's not coming
-      // back — stop waiting immediately instead of burning the rest of the
-      // budget. A LIVE child that simply hasn't reported yet (npm/AV
-      // contention on a freshly-written node_modules right after install,
-      // measured once at ~142s vs the normal ~5-9s — #142 follow-up) keeps
-      // getting the benefit of the doubt up to HARD_CEILING_ATTEMPTS instead
-      // of being killed on a fixed guess.
-      if (attempt >= CONFIRM_ATTEMPTS && !isPidAlive(child.pid)) break;
-      // 1) Authoritative: child self-reported its bound port. Identity comes
-      // from BOUND_REPORT's own per-invocation-unique path (nothing else on
-      // the machine knows it, since it's only handed to this child via env),
-      // NOT a pid match: under shell:true (#141's Windows EINVAL fix),
-      // child.pid is the wrapping cmd.exe's pid, not the real server's —
-      // rep.pid !== child.pid always, so a pid comparison here can never
-      // succeed on the npx-fallback path regardless of how long we wait
-      // (#143). rep.pid is the real server pid — use it for control.json.
-      try {
-        const rep = JSON.parse(fs.readFileSync(BOUND_REPORT, 'utf8'));
-        if (rep && typeof rep.pid === 'number' && typeof rep.port === 'number') {
-          try { fs.unlinkSync(BOUND_REPORT); } catch { /* ignore */ }
-          writeStatus(rep.pid, rep.port);
-          if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] server bound to port ${rep.port} (pid ${rep.pid})\n`);
-          return;
-        }
-      } catch { /* not written yet or old server — fall through to probe */ }
-      // 2) Fallback: pid-matched HTTP probe (old servers without report support)
-      for (let delta = 0; delta <= 10; delta++) {
-        const p = DEFAULT_PORT + delta;
-        const responderPid = await probePort(p);
-        if (responderPid === false) continue;
-        if (responderPid === child.pid) {
-          if (p !== DEFAULT_PORT) {
-            writeStatus(child.pid, p);
-            if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] server bound to port ${p} (updated control.json)\n`);
-          }
-          return;
-        }
-        if (p === DEFAULT_PORT && (typeof responderPid === 'number' || responderPid === 'foreign-authwalled')) {
-          sawForeignOnDefault = true;
-        }
-        // pid mismatch or unreadable — not provably ours, keep scanning
-      }
-    }
-    try { fs.unlinkSync(BOUND_REPORT); } catch { /* ignore */ }
-    if (sawForeignOnDefault) {
-      // Another project's server owns DEFAULT_PORT and our child never proved
-      // its own port — point control.json at the live server instead of lying,
-      // and kill our redundant child.
-      try { process.kill(child.pid, 'SIGTERM'); } catch { /* already gone */ }
-      if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] port ${DEFAULT_PORT} is served by another project's control server — reusing it (killed redundant child)\n`);
-      let foreignPid = await probePort(DEFAULT_PORT);
-      if (typeof foreignPid !== 'number' || foreignPid <= 0) {
-        try {
-          const { execFileSync } = require('child_process');
-          const lsofOut = execFileSync('lsof', ['-ti', `:${DEFAULT_PORT}`, '-sTCP:LISTEN'], { encoding: 'utf8', timeout: 3000 }).trim();
-          const parsedPid = parseInt(lsofOut.split('\n')[0], 10);
-          if (Number.isInteger(parsedPid) && parsedPid > 0) foreignPid = parsedPid;
-        } catch { /* ignore */ }
-      }
-      writeStatus(typeof foreignPid === 'number' ? foreignPid : 0, DEFAULT_PORT);
-      // Pair with the foreign server: resolve its project dir from its pid,
-      // copy its dashboard-token beside OUR control.json (ingest is
-      // default-deny — without this every event from this project 401s
-      // silently), and self-register in its known-projects so future token
-      // rotations propagate back here on server restart.
-      try {
-        if (typeof foreignPid === 'number' && foreignPid > 0) {
-          const { execFileSync } = require('child_process');
-          const out = execFileSync('lsof', ['-a', '-p', String(foreignPid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', timeout: 3000 });
-          const nLine = out.split('\n').find((l) => l.startsWith('n'));
-          const serverHome = nLine ? nLine.slice(1) : null;
-          if (serverHome) {
-            const srcTok = path.join(serverHome, '.monomind', 'dashboard-token');
-            const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
-            if (fs.existsSync(srcTok)) {
-              fs.copyFileSync(srcTok, dstTok);
-              fs.chmodSync(dstTok, 0o600);
-            }
-            const kpFile = path.join(serverHome, 'data', 'known-projects.json');
-            try {
-              const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
-              if (Array.isArray(kp) && !kp.includes(CWD)) {
-                kp.push(CWD);
-                fs.writeFileSync(kpFile, JSON.stringify(kp));
-              }
-            } catch { /* registry unreadable — token copy alone still unblocks events */ }
-            process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
-          }
-        }
-      } catch { /* pairing is best-effort; propagation-on-restart is the fallback */ }
-      return;
-    }
-    // Server never became reachable on any expected port — kill the child
-    // rather than leave an orphan bound to some port nothing will ever read.
-    // The next session-start simply retries.
-    try { process.kill(child.pid, 'SIGTERM'); } catch { /* already gone */ }
-    try { fs.unlinkSync(STATUS_FILE); } catch { /* ignore */ }
-    process.stdout.write(`[control] server did not respond within ${((attempt + 1) * 500 / 1000).toFixed(1)} s — killed orphan, will retry next session\n`);
-  }
-
-  confirmPort().catch(() => {}).finally(() => { releaseSpawnLock(); process.exit(0); });
-}
-
-main().catch((err) => {
-  if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") {
-    process.stderr.write(`[control] failed to start: ${err && err.message ? err.message : err}\n`);
-  }
   releaseSpawnLock();
   process.exit(0);
-});
+}
+
+if (String(process.env.MONOMIND_CONTROL_CONFIRM_MODE || '') === '1') {
+  // Standalone confirmation process spawned by main() above — see runConfirm's
+  // doc comment. Not itself subject to the SessionStart hook's 5s timeout.
+  runConfirm({
+    childPid: Number(process.env.MONOMIND_CONTROL_CONFIRM_PID),
+    port: Number(process.env.MONOMIND_CONTROL_CONFIRM_PORT) || DEFAULT_PORT,
+    boundReportPath: process.env.MONOMIND_CONTROL_CONFIRM_REPORT,
+    isNpxFallback: process.env.MONOMIND_CONTROL_CONFIRM_NPX === '1',
+  }).catch(() => {}).finally(() => process.exit(0));
+} else {
+  main().catch((err) => {
+    if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") {
+      process.stderr.write(`[control] failed to start: ${err && err.message ? err.message : err}\n`);
+    }
+    releaseSpawnLock();
+    process.exit(0);
+  });
+}

--- a/tests/hooks/control-start.test.mjs
+++ b/tests/hooks/control-start.test.mjs
@@ -194,7 +194,10 @@ describe('control-start: confirmPort waits on liveness, not a fixed budget (#142
   it('only gives up early, before the hard ceiling, once the child has actually exited', () => {
     const src = fs.readFileSync(SCRIPT, 'utf-8');
     expect(src).toMatch(/attempt\s*<\s*HARD_CEILING_ATTEMPTS/);
-    expect(src).toMatch(/attempt\s*>=\s*CONFIRM_ATTEMPTS\s*&&\s*!isPidAlive\(child\.pid\)/);
+    // childPid, not child.pid: runConfirm (see #144 below) takes a plain pid
+    // number, since it runs in its own process and no longer has the
+    // original ChildProcess object to read .pid off of.
+    expect(src).toMatch(/attempt\s*>=\s*CONFIRM_ATTEMPTS\s*&&\s*!isPidAlive\(childPid\)/);
     const ceilingMatch = src.match(/HARD_CEILING_ATTEMPTS\s*=\s*(\d+)/);
     expect(ceilingMatch).not.toBeNull();
     const hardCeilingAttempts = Number(ceilingMatch[1]);
@@ -203,5 +206,28 @@ describe('control-start: confirmPort waits on liveness, not a fixed budget (#142
     // The ceiling must be strictly larger than the npx-fallback grace period,
     // or it isn't a safety net at all — just the same budget renamed.
     expect(hardCeilingAttempts).toBeGreaterThan(npxAttempts);
+  });
+});
+
+describe('control-start: confirmation runs detached from the hook-invoked process (#144)', () => {
+  // The SessionStart hook that invokes this script has only a 5s timeout
+  // (settings.json), far short of what confirmPort/runConfirm can
+  // legitimately need (up to HARD_CEILING_ATTEMPTS's ~5 min). Awaiting
+  // confirmation inline meant the hook almost always got the process killed
+  // mid-wait before #142/#143's own fixes ever got a chance to run — control
+  // .json stayed stuck on its pre-confirmation optimistic guess every time
+  // resolution took longer than ~4.5s, which per #142's own measurements is
+  // the common case, not the exception. Confirmation now runs in a second,
+  // fully independent detached process instead, so the hook-invoked process
+  // can write the optimistic status and exit immediately — matching this
+  // file's own module docstring ("exits immediately after spawning").
+  it('spawns a detached confirm-mode process and returns without awaiting it', () => {
+    const src = fs.readFileSync(SCRIPT, 'utf-8');
+    expect(src).toMatch(/MONOMIND_CONTROL_CONFIRM_MODE:\s*'1'/);
+    expect(src).toMatch(/detached:\s*true/);
+    // main() must not itself await runConfirm/confirmPort — it hands off and
+    // returns. There should be no `await runConfirm` or `await confirmPort`
+    // left anywhere in the file.
+    expect(src).not.toMatch(/await\s+(runConfirm|confirmPort)\(/);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #144.

`confirmPort()` (via #142/#143's own fixes) can legitimately need up to ~5 minutes on a cold npx resolve or under AV/filesystem contention right after an install — that's the whole point of `HARD_CEILING_ATTEMPTS`. But it ran **inline** inside the same process the `SessionStart` hook kills at a 5s timeout (`settings.json`). In real usage, that process almost always got truncated before confirmation ever completed — defeating #142/#143's fixes in practice and leaving `control.json` stuck on its pre-confirmation optimistic guess (wrong pid too, since under `shell:true` that's the wrapping `cmd.exe`'s pid, not the real server's).

## What changed

Split the work into two processes instead of one:

- `main()` spawns the dashboard, writes the optimistic status, then hands confirmation off to a **second, fully detached process** (`MONOMIND_CONTROL_CONFIRM_MODE=1`) and exits immediately — which is what this file's own module docstring already claimed ("Called from SessionStart hook — exits immediately after spawning"), but wasn't actually true before this change.
- The confirmation loop (previously an inline `confirmPort()` closure) is now `runConfirm()`, a standalone module-level function that takes a plain pid number instead of a `ChildProcess` object (it no longer has one — it's running in its own process), and can take as long as it legitimately needs without the hook's timeout ever touching it.
- `probePort()` moved to module scope so both `main()`'s adoption-probe loop and the new standalone `runConfirm()` can share it.

## Verification (Windows, manual)

- Hook-invoked process now returns in **~0.4-2s** regardless of npx resolve time, vs. previously blocking on `confirmPort()` until it resolved or got killed.
- Confirmation completes correctly in the background: `control.json` gets updated with the real server pid within ~1s of the dashboard actually binding.
- Proved true process independence: killed the hook-invoked process 2s after spawn (well before its own natural ~0.4s exit even had a chance not to matter) — the detached confirm process still completed and updated `control.json` correctly, with the dashboard live and responding.

## Tests

- `pnpm vitest run tests/hooks/control-start.test.mjs` — 13/13 passing.
- Updated the #142-follow-up liveness test for `runConfirm`'s `childPid` parameter rename (source-pattern assertion, no behavior change).
- Added a new test asserting `main()` hands off to a detached confirm-mode process and never itself awaits `runConfirm`/`confirmPort` — deliberately a source-pattern assertion, not a real-spawn test, consistent with this suite's existing approach (real spawns in CI were already flagged as leaking hundreds of orphan processes — see the `MONOMIND_CONTROL_NO_SPAWN` comment already in this file).
- `pnpm biome check` on the changed files: 0 new issues (the pre-existing 1 error / 5 infos on the test file's import style already existed before this change — confirmed via `git stash`, left untouched as out of scope for this fix).

## Files

Synced across all three tracked copies of this file (root `.claude/`, `.gemini/`, `packages/@monomind/cli/.claude/`) — `git log` shows these have always been changed together in past commits (#142/#143's own commits touched all three).