### PR TITLE
fix(hooks): resolve #150 — control-start.cjs trusts a live-but-auth-mismatched dashboard; org run never verifies/heals it

### DIFF
--- a/.claude/helpers/control-start.cjs
+++ b/.claude/helpers/control-start.cjs
@@ -99,6 +99,17 @@ function readAuthCredential() {
   } catch { return ''; }
 }
 
+// Resolves to the parsed /api/status body, 'unauthorized' if a server answered
+// but rejected our current dashboard-token (401 — the pairing recorded in
+// control.json no longer matches what that server actually expects, e.g.
+// stale state left over from a prior collision/restart), or null for "no
+// server there at all" (connection error, timeout, or 5xx). These used to
+// collapse into a single null result, which meant a stale-token server was
+// indistinguishable from a healthy one to the caller below — the "already
+// running" check had no way to tell "reachable but I can't actually talk to
+// it" from "not reachable", so it trusted a server it could never
+// authenticate against as healthy and exited immediately instead of fixing
+// the pairing.
 function probeStatus(p) {
   const http = require('http');
   const cred = readAuthCredential();
@@ -110,7 +121,8 @@ function probeStatus(p) {
       let body = '';
       res.on('data', (c) => { if (body.length < 64 * 1024) body += c; });
       res.on('end', () => {
-        if (res.statusCode >= 500 || res.statusCode === 401) return resolve(null);
+        if (res.statusCode === 401) return resolve('unauthorized');
+        if (res.statusCode >= 500) return resolve(null);
         try { resolve(JSON.parse(body)); } catch { resolve({}); }
       });
     });
@@ -305,13 +317,19 @@ async function main() {
   const status = readStatus();
   if (status && status.pid && isPidAlive(status.pid)) {
     const live = await probeStatus(status.port);
-    const staleProject = live && live.dir && path.resolve(live.dir) !== path.resolve(CWD);
+    // A server that's up but rejects our token is unusable to us regardless
+    // of whose project it's rooted in or how old it is — force a restart the
+    // same as any other staleness reason instead of accepting it as healthy.
+    const staleAuth = live === 'unauthorized';
+    const staleProject = live && live !== 'unauthorized' && live.dir && path.resolve(live.dir) !== path.resolve(CWD);
     const startedMs = status.startedAt ? Date.now() - new Date(status.startedAt).getTime() : 0;
     const staleBuild = startedMs > 7 * 24 * 3600_000; // older than 7 days
-    if (staleProject || staleBuild) {
-      const reason = staleProject
-        ? `rooted in ${live.dir}, not ${CWD}`
-        : `started ${Math.round(startedMs / 86400_000)}d ago`;
+    if (staleAuth || staleProject || staleBuild) {
+      const reason = staleAuth
+        ? `token mismatch — server on port ${status.port} rejected our dashboard-token`
+        : staleProject
+          ? `rooted in ${live.dir}, not ${CWD}`
+          : `started ${Math.round(startedMs / 86400_000)}d ago`;
       if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] restarting stale server (${reason})\n`);
       try { process.kill(status.pid, 'SIGTERM'); } catch { /* already gone */ }
       // Give it a moment to release the port

--- a/.gemini/helpers/control-start.cjs
+++ b/.gemini/helpers/control-start.cjs
@@ -99,6 +99,17 @@ function readAuthCredential() {
   } catch { return ''; }
 }
 
+// Resolves to the parsed /api/status body, 'unauthorized' if a server answered
+// but rejected our current dashboard-token (401 — the pairing recorded in
+// control.json no longer matches what that server actually expects, e.g.
+// stale state left over from a prior collision/restart), or null for "no
+// server there at all" (connection error, timeout, or 5xx). These used to
+// collapse into a single null result, which meant a stale-token server was
+// indistinguishable from a healthy one to the caller below — the "already
+// running" check had no way to tell "reachable but I can't actually talk to
+// it" from "not reachable", so it trusted a server it could never
+// authenticate against as healthy and exited immediately instead of fixing
+// the pairing.
 function probeStatus(p) {
   const http = require('http');
   const cred = readAuthCredential();
@@ -110,7 +121,8 @@ function probeStatus(p) {
       let body = '';
       res.on('data', (c) => { if (body.length < 64 * 1024) body += c; });
       res.on('end', () => {
-        if (res.statusCode >= 500 || res.statusCode === 401) return resolve(null);
+        if (res.statusCode === 401) return resolve('unauthorized');
+        if (res.statusCode >= 500) return resolve(null);
         try { resolve(JSON.parse(body)); } catch { resolve({}); }
       });
     });
@@ -305,13 +317,19 @@ async function main() {
   const status = readStatus();
   if (status && status.pid && isPidAlive(status.pid)) {
     const live = await probeStatus(status.port);
-    const staleProject = live && live.dir && path.resolve(live.dir) !== path.resolve(CWD);
+    // A server that's up but rejects our token is unusable to us regardless
+    // of whose project it's rooted in or how old it is — force a restart the
+    // same as any other staleness reason instead of accepting it as healthy.
+    const staleAuth = live === 'unauthorized';
+    const staleProject = live && live !== 'unauthorized' && live.dir && path.resolve(live.dir) !== path.resolve(CWD);
     const startedMs = status.startedAt ? Date.now() - new Date(status.startedAt).getTime() : 0;
     const staleBuild = startedMs > 7 * 24 * 3600_000; // older than 7 days
-    if (staleProject || staleBuild) {
-      const reason = staleProject
-        ? `rooted in ${live.dir}, not ${CWD}`
-        : `started ${Math.round(startedMs / 86400_000)}d ago`;
+    if (staleAuth || staleProject || staleBuild) {
+      const reason = staleAuth
+        ? `token mismatch — server on port ${status.port} rejected our dashboard-token`
+        : staleProject
+          ? `rooted in ${live.dir}, not ${CWD}`
+          : `started ${Math.round(startedMs / 86400_000)}d ago`;
       if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] restarting stale server (${reason})\n`);
       try { process.kill(status.pid, 'SIGTERM'); } catch { /* already gone */ }
       // Give it a moment to release the port

--- a/packages/@monomind/cli/.claude/helpers/control-start.cjs
+++ b/packages/@monomind/cli/.claude/helpers/control-start.cjs
@@ -99,6 +99,17 @@ function readAuthCredential() {
   } catch { return ''; }
 }
 
+// Resolves to the parsed /api/status body, 'unauthorized' if a server answered
+// but rejected our current dashboard-token (401 — the pairing recorded in
+// control.json no longer matches what that server actually expects, e.g.
+// stale state left over from a prior collision/restart), or null for "no
+// server there at all" (connection error, timeout, or 5xx). These used to
+// collapse into a single null result, which meant a stale-token server was
+// indistinguishable from a healthy one to the caller below — the "already
+// running" check had no way to tell "reachable but I can't actually talk to
+// it" from "not reachable", so it trusted a server it could never
+// authenticate against as healthy and exited immediately instead of fixing
+// the pairing.
 function probeStatus(p) {
   const http = require('http');
   const cred = readAuthCredential();
@@ -110,7 +121,8 @@ function probeStatus(p) {
       let body = '';
       res.on('data', (c) => { if (body.length < 64 * 1024) body += c; });
       res.on('end', () => {
-        if (res.statusCode >= 500 || res.statusCode === 401) return resolve(null);
+        if (res.statusCode === 401) return resolve('unauthorized');
+        if (res.statusCode >= 500) return resolve(null);
         try { resolve(JSON.parse(body)); } catch { resolve({}); }
       });
     });
@@ -305,13 +317,19 @@ async function main() {
   const status = readStatus();
   if (status && status.pid && isPidAlive(status.pid)) {
     const live = await probeStatus(status.port);
-    const staleProject = live && live.dir && path.resolve(live.dir) !== path.resolve(CWD);
+    // A server that's up but rejects our token is unusable to us regardless
+    // of whose project it's rooted in or how old it is — force a restart the
+    // same as any other staleness reason instead of accepting it as healthy.
+    const staleAuth = live === 'unauthorized';
+    const staleProject = live && live !== 'unauthorized' && live.dir && path.resolve(live.dir) !== path.resolve(CWD);
     const startedMs = status.startedAt ? Date.now() - new Date(status.startedAt).getTime() : 0;
     const staleBuild = startedMs > 7 * 24 * 3600_000; // older than 7 days
-    if (staleProject || staleBuild) {
-      const reason = staleProject
-        ? `rooted in ${live.dir}, not ${CWD}`
-        : `started ${Math.round(startedMs / 86400_000)}d ago`;
+    if (staleAuth || staleProject || staleBuild) {
+      const reason = staleAuth
+        ? `token mismatch — server on port ${status.port} rejected our dashboard-token`
+        : staleProject
+          ? `rooted in ${live.dir}, not ${CWD}`
+          : `started ${Math.round(startedMs / 86400_000)}d ago`;
       if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] restarting stale server (${reason})\n`);
       try { process.kill(status.pid, 'SIGTERM'); } catch { /* already gone */ }
       // Give it a moment to release the port

--- a/packages/@monomind/cli/src/commands/org.ts
+++ b/packages/@monomind/cli/src/commands/org.ts
@@ -290,17 +290,46 @@ const runAction = async (ctx: CommandContext): Promise<CommandResult> => {
   log(output.info(`org ${name} running (${running.def.roles.length} agents, run ${running.run}) — Ctrl-C or "monomind org stop ${name}" to stop`));
 
   // P1-12: Print the dashboard URL so CLI users know where to look.
-  // The dashboard is spawned by a Claude Code SessionStart hook
-  // (.claude/helpers/control-start.cjs); pure-CLI users need to know this.
+  // The dashboard is normally spawned by a Claude Code SessionStart hook
+  // (.claude/helpers/control-start.cjs) — but `org run` doesn't require
+  // Claude Code, and even when the hook exists it only fires once at
+  // session start, not per org run. If control.json is stale (points at a
+  // dead pid, a server rooted in a different project, or one that no longer
+  // accepts our dashboard-token — the exact case control-start.cjs's own
+  // "already running" check now self-heals, see its staleAuth handling),
+  // `org run` used to just print whatever URL was on file with zero
+  // verification. Actively (re)run the same control-start.cjs the hook
+  // uses, from this project's own .claude/helpers/ if it's been set up
+  // (monomind init), so a stale/dead/mismatched dashboard gets healed on
+  // every org run instead of silently trusting old state.
   const controlPath = join(ctx.cwd, '.monomind', 'control.json');
+  const controlStartPath = join(ctx.cwd, '.claude', 'helpers', 'control-start.cjs');
+  if (existsSync(controlStartPath)) {
+    try {
+      const { spawnSync } = await import('node:child_process');
+      spawnSync(process.execPath, [controlStartPath], {
+        cwd: ctx.cwd,
+        env: { ...process.env, CLAUDE_PROJECT_DIR: ctx.cwd, MONOMIND_HOOK_QUIET: '1' },
+        timeout: 5000,
+        stdio: 'ignore',
+      });
+    } catch { /* best-effort — fall through to whatever control.json already has */ }
+  }
   if (existsSync(controlPath)) {
     try {
       const ctl = JSON.parse(readFileSync(controlPath, 'utf8')) as { port?: number; url?: string };
       const dashUrl = ctl.url || (ctl.port ? `http://localhost:${ctl.port}` : 'http://localhost:4242');
       log(output.dim(`  Dashboard: ${dashUrl}`));
     } catch { /* non-critical */ }
+  } else if (existsSync(controlStartPath)) {
+    // control-start.cjs ran above (spawnSync'd synchronously with a 5s cap)
+    // but control.json still doesn't exist — its own confirm-mode child is
+    // still working in the background (npx cold-resolve etc., #142/#144)
+    // rather than having failed outright. Point at the default port; the
+    // confirm process will correct control.json once it lands.
+    log(output.dim('  Dashboard: http://localhost:4242 (starting — check back in a few seconds if unreachable)'));
   } else {
-    log(output.dim('  Dashboard: open Claude Code to launch it, or run: monomind org dashboard'));
+    log(output.dim('  Dashboard: run `monomind init` to set up .claude/helpers/, then re-run to launch it automatically'));
   }
 
   // stopfile poll lets `org stop` work from another terminal; the daemon can

--- a/tests/hooks/control-start.test.mjs
+++ b/tests/hooks/control-start.test.mjs
@@ -97,6 +97,51 @@ describe('control-start: already running', () => {
   });
 });
 
+describe('control-start: stale-token pairing self-heals instead of being trusted', () => {
+  // Regression: probeStatus() used to collapse "no server there" and
+  // "a server answered but rejected our dashboard-token" into the same null
+  // result, so a live-but-mismatched server (e.g. left over from a port
+  // collision that pushed the real dashboard onto a different port while
+  // control.json still pointed at the old one) was indistinguishable from a
+  // healthy one — the "already running" check trusted it and exited 0
+  // without ever actually being able to talk to it.
+  it('treats a 401 from the recorded port as stale and attempts a restart, not "already running"', async () => {
+    const { spawn } = await import('child_process');
+    const port = isolatedPort();
+    // run() below uses spawnSync, which blocks this test process's entire
+    // event loop until control-start.cjs exits — an in-process
+    // http.createServer() mock would never get a chance to answer the very
+    // request that spawnSync is synchronously waiting on. The mock server
+    // has to live in its own separate process so its event loop keeps
+    // running independently of this one being blocked.
+    const mockScript = path.join(tmpDir, 'mock401.cjs');
+    fs.writeFileSync(mockScript, `
+      const http = require('http');
+      const server = http.createServer((req, res) => {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Unauthorized: missing or invalid auth token' }));
+      });
+      server.listen(${port}, 'localhost', () => process.stderr.write('READY'));
+    `);
+    const mock = spawn(process.execPath, [mockScript], { stdio: ['ignore', 'ignore', 'pipe'] });
+    await new Promise((resolve) => mock.stderr.on('data', resolve));
+    // control-start.cjs's own staleAuth restart path SIGTERMs the recorded
+    // pid — must NOT be this test process's own pid (would kill the test
+    // runner). Use a real, alive, harmless child instead.
+    const sentinel = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)']);
+    try {
+      writeControlJson(tmpDir, sentinel.pid, port);
+      const r = run({ cwd: tmpDir });
+      expect(r.stdout).not.toContain('already running');
+      expect(r.stdout).toContain('restarting stale server');
+      expect(r.stdout).toContain('token mismatch');
+    } finally {
+      sentinel.kill('SIGTERM');
+      mock.kill('SIGTERM');
+    }
+  });
+});
+
 // ── not running ──────────────────────────────────────────────────────────────
 
 describe('control-start: not running', () => {


### PR DESCRIPTION
## Summary

Fixes #150.

Two related gaps let a running org's dashboard show zero activity with no error anywhere:

1. `probeStatus()` collapsed "no server there" and "a server answered but rejected our dashboard-token" into the same `null` result, so the "already running" check had no way to tell a healthy server from a stale one that's still alive but mismatched — it just trusted it.
2. `monomind org run` never verified or triggered the dashboard at all — it only echoed whatever `control.json` already had.

## Repro

Reproduced live during a real ~10-minute org run (585 events, 26 messages) — the dashboard showed zero activity the entire time because `control.json` pointed at a token-mismatched server left over from an earlier port collision:

```
$ curl http://localhost:4242/api/status -H "x-monomind-token: $(cat .monomind/dashboard-token)"
{"error":"Unauthorized: missing or invalid auth token"}
```

Yet `control-start.cjs` printed `[control] already running on port 4242 (pid ...)` and exited 0.

## Fix

- `probeStatus()` now returns a distinct `'unauthorized'` sentinel for a 401 instead of collapsing it into `null` — mirrors the existing `'foreign-authwalled'` sentinel `probePort()` already uses for the same kind of distinction.
- The "already running" check treats `'unauthorized'` as stale (`staleAuth`), same as `staleProject`/`staleBuild`, and restarts.
- `org run` now actively (re)invokes the project's own `.claude/helpers/control-start.cjs` (if `monomind init` has set one up) on every run instead of passively trusting `control.json` — so a stale/dead/mismatched dashboard self-heals on every org run, not only once at Claude Code `SessionStart`.

## Verification

Built a mock server that always answers 401 on the dashboard port, pointed `control.json` at it (simulating the exact stale-pairing scenario), then ran the precise `spawnSync` path `org.ts`'s new code uses:

```
MOCK: MOCK READY pid=18764
control-start.cjs exit status: 0
mock still alive after heal attempt: false
control.json after heal: {"pid":14520,"port":4242,...}
RESULT: PASS — stale mismatched server was killed and replaced
```

Then confirmed the new server authenticates correctly with the new token (`200`, correct `dir`, correct `activeOrgs`).

## Tests

- `pnpm vitest run tests/hooks/control-start.test.mjs` — 14/14 passing (13 existing + 1 new).
- New regression test uses a genuinely separate spawned mock-server process, not an in-process `http.createServer()` — worth calling out why: the test harness's `run()` helper uses `spawnSync`, which blocks the entire test process's event loop for the duration of the child it's waiting on. An in-process mock server would never get a chance to answer the very request `spawnSync` is synchronously blocked on. Took a couple of failed attempts (documented in my own debugging, not included in this diff) before landing on spawning the mock as a fully independent process.
- `pnpm run build` (CLI package) — clean, no new TypeScript errors (had to build sibling workspace packages first in this fresh clone — `@monoes/monograph`, `@monoes/hooks`, `@monoes/memory`, `@monoes/mcp`, `@monoes/routing` — unrelated to this change, just fresh-clone setup).
- `pnpm biome check` on all changed files: 0 new issues (confirmed via `git stash` that the pre-existing counts on `org.ts` and the test file are unchanged).
- Ran the full `tests/hooks/` suite as a broader regression check: some unrelated pre-existing Windows-specific `EPERM` temp-cleanup flakiness in `session-restore-handler.test.mjs` and others — confirmed via `git stash` this reproduces identically on a clean `main`, unrelated to this change.

## Files

Synced `control-start.cjs` across all three tracked copies (root `.claude/`, `.gemini/`, `packages/@monomind/cli/.claude/`).