### PR TITLE
fix(orgrt): resolve #152 — org_complete drain timeout no longer hides which roles were cut off

### DIFF
--- a/packages/@monomind/cli/src/__tests__/org-stop-timeout-roster.test.ts
+++ b/packages/@monomind/cli/src/__tests__/org-stop-timeout-roster.test.ts
@@ -1,0 +1,107 @@
+/**
+ * #152: when stopOrg()'s drain window (finishStop in daemon.ts) expires with
+ * agent sessions still mid-turn, the audit event used to say only "proceeding
+ * anyway" — no way for a run reviewer to tell whether real, in-progress work
+ * (a mid-build, a mid-write) got force-stopped, or the window simply outlived
+ * a couple of already-idle sessions.
+ *
+ * A real OrgDaemon + real OrgBus/Mailbox are used with a directly-injected
+ * RunningOrg (`daemon.orgs` is `@internal`, not private) so the drain-timeout
+ * roster logic runs for real — only the two AgentRuntime.done promises are
+ * faked, since standing up real agent sessions would test the SDK instead of
+ * this behaviour (same rationale as org-stopfile-poll.test.ts).
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { OrgBus } from '../orgrt/bus.js';
+import { type AgentRuntime, OrgDaemon, type RunningOrg } from '../orgrt/daemon.js';
+import { Mailbox } from '../orgrt/mailbox.js';
+import type { BusEvent, OrgDef } from '../orgrt/types.js';
+
+function fakeAgent(status: AgentRuntime['status'], done: Promise<void>): AgentRuntime {
+  return {
+    mailbox: new Mailbox(),
+    // finishStop() doesn't read policy/scrollback — untyped stand-ins are fine here.
+    policy: {} as AgentRuntime['policy'],
+    done,
+    status,
+    metrics: { tokens: 0, costUsd: 0 },
+    scrollback: {
+      push: () => {},
+      all: () => [],
+      snapshot: () => [],
+    } as unknown as AgentRuntime['scrollback'],
+  };
+}
+
+describe('finishStop reports which roles were still active at the drain timeout (#152)', () => {
+  let dir: string;
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  });
+
+  it('names the still-running role in the stop-timeout audit event, not the already-ended one', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'org-stop-roster-'));
+    const daemon = new OrgDaemon(dir, { stopWaitMs: 30 });
+    const bus = new OrgBus('testorg', 'run1', dir);
+    const events: BusEvent[] = [];
+    bus.subscribe((e) => events.push(e));
+
+    // 'busy-worker' never resolves within the 30ms drain window — mid-turn,
+    // exactly the case a real still-building agent looks like. 'done-worker'
+    // already resolved and flipped to 'ended' before stop was even called.
+    const running: RunningOrg = {
+      def: { name: 'testorg', roles: [] } as unknown as OrgDef,
+      run: 'run1',
+      bus,
+      agents: new Map([
+        ['busy-worker', fakeAgent('running', new Promise<void>(() => {}))],
+        ['done-worker', fakeAgent('ended', Promise.resolve())],
+      ]),
+      busEvents: () => events,
+    };
+    daemon.orgs.set('testorg', running);
+
+    await daemon.stopOrg('testorg');
+
+    const timeoutEvent = events.find((e) => e.reason === 'stop-timeout');
+    expect(timeoutEvent).toBeDefined();
+    expect(timeoutEvent!.msg).toContain('busy-worker');
+    expect(timeoutEvent!.msg).not.toContain('done-worker');
+    expect((timeoutEvent!.data as { stillActive?: string[] } | undefined)?.stillActive).toEqual([
+      'busy-worker',
+    ]);
+  });
+
+  it('omits the roster suffix entirely when every role already ended before the timeout fires', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'org-stop-roster-'));
+    const daemon = new OrgDaemon(dir, { stopWaitMs: 30 });
+    const bus = new OrgBus('testorg2', 'run1', dir);
+    const events: BusEvent[] = [];
+    bus.subscribe((e) => events.push(e));
+
+    // Both agents are already 'ended', but their `done` promises resolve
+    // just past the 30ms drain window — a timeout still fires (the drain
+    // race lost by a hair), but nothing was actually cut off mid-work.
+    const running: RunningOrg = {
+      def: { name: 'testorg2', roles: [] } as unknown as OrgDef,
+      run: 'run1',
+      bus,
+      agents: new Map([
+        ['worker-a', fakeAgent('ended', new Promise<void>((r) => setTimeout(r, 200)))],
+      ]),
+      busEvents: () => events,
+    };
+    daemon.orgs.set('testorg2', running);
+
+    await daemon.stopOrg('testorg2');
+
+    const timeoutEvent = events.find((e) => e.reason === 'stop-timeout');
+    expect(timeoutEvent).toBeDefined();
+    expect(timeoutEvent!.msg).not.toContain('still active');
+    expect((timeoutEvent!.data as { stillActive?: string[] } | undefined)?.stillActive).toEqual([]);
+  });
+});

--- a/packages/@monomind/cli/src/orgrt/daemon.ts
+++ b/packages/@monomind/cli/src/orgrt/daemon.ts
@@ -1299,10 +1299,24 @@ export class OrgDaemon {
       new Promise<boolean>((r) => setTimeout(() => r(true), stopWaitMs)),
     ]);
     if (timedOut) {
+      // #152: "proceeding anyway" alone didn't say WHO got cut off — a run
+      // reviewer had no way to tell whether real, in-progress work (a
+      // mid-build, a mid-write) was force-stopped, or the drain window
+      // simply outlived a handful of already-idle sessions. status is only
+      // 'ended'/'crashed' once a role's session promise has actually
+      // settled; still 'running' here means it was mid-turn when the
+      // ceiling hit, not merely idle-but-not-yet-reaped.
+      const stillActive = [...org.agents.entries()]
+        .filter(([, a]) => a.status === 'running')
+        .map(([roleId]) => roleId);
+      const rosterSuffix = stillActive.length
+        ? ` — still active: ${stillActive.join(', ')}`
+        : '';
       org.bus.emit({
         type: 'audit',
-        msg: `org stop timed out after ${stopWaitMs}ms waiting for agent sessions to finish — proceeding anyway`,
+        msg: `org stop timed out after ${stopWaitMs}ms waiting for agent sessions to finish — proceeding anyway${rosterSuffix}`,
         reason: 'stop-timeout',
+        data: { stillActive },
       });
       // Reap only SDK processes spawned by THIS node process — ownerPid filter
       // ensures other `monomind org run` daemons' agents are untouched.

--- a/packages/@monomind/cli/src/orgrt/session.ts
+++ b/packages/@monomind/cli/src/orgrt/session.ts
@@ -535,7 +535,7 @@ export function buildOrgTools(opts: SessionOpts): OrgToolDef[] {
   if (opts.onComplete) {
     tools.push({
       name: 'org_complete',
-      description: 'Record the outcome of this run. Call exactly once, when the goal is achieved or clearly cannot be. The outcome and summary are persisted to the org run history and briefed to the next run.',
+      description: 'Record the outcome of this run. Call exactly once, when the goal is achieved or clearly cannot be. This ends the run: check org_tasks first — siblings with in-progress work only get a short drain window to finish before being cut off, so do not call this while others are still mid-build or mid-edit unless the run genuinely cannot continue. The outcome and summary are persisted to the org run history and briefed to the next run.',
       schema: { outcome: z.enum(['achieved', 'partial', 'failed']), summary: z.string() },
       handler: async (args) => {
         opts.onComplete!(role.id, args.outcome as 'achieved' | 'partial' | 'failed', args.summary as string);


### PR DESCRIPTION
## Summary

Fixes #152.

On a real 22-role org run, the boss called `org_complete` while six workers were still actively writing real files. The planned-completion drain window (5 min) let most finish, but at least one worker was still mid-write when it expired and got force-stopped — and the resulting audit event said only *"org stop timed out after Xms ... proceeding anyway"*, with no way to tell which roles (if any) had real, in-progress work cut off versus which were merely idle-but-not-yet-reaped.

## Fix

- `finishStop()` now collects every role still `AgentRuntime.status === 'running'` (mid-turn, not yet settled) at the moment the drain window expires, and includes that roster both in the audit message and as structured `data.stillActive` on the event. A run reviewer can now tell "6 workers were cut off mid-task" from "nothing was actually lost" — the roster is empty in the latter case and the message omits the `" — still active: ..."` suffix entirely rather than printing a hollow one.
- `org_complete`'s tool description now tells the boss to check `org_tasks` and avoid calling it while siblings still have in-progress work, rather than only describing *when* to call it. The tool description is the one place this guidance reaches the model right at the moment it's making the call.

## Tests

- New `org-stop-timeout-roster.test.ts`: injects a `RunningOrg` into a real `OrgDaemon` (with a real `OrgBus`/`Mailbox`, `stopWaitMs` overridden short via the existing test-only `DaemonOpts` field) — only the two `AgentRuntime.done` promises are faked, following the same precedent `org-stopfile-poll.test.ts` sets for not standing up real agent sessions to test daemon-level orchestration logic. Asserts:
  - a still-running role appears in both the audit message and `data.stillActive`
  - an already-ended role does not
  - the roster suffix is omitted entirely when nothing was actually cut off (both agents already `'ended'`, timeout only won the race by a hair)
- `pnpm vitest run src/__tests__/org-stop-timeout-roster.test.ts` — 2/2 passing.
- Broader regression pass: `org-stopfile-poll.test.ts`, `org-runfile-poll.test.ts`, `org-approval-gate.test.ts`, `tool-fence.test.ts` — 37/37 passing.
- `pnpm run build` (CLI package) — clean.
- `pnpm biome check` on all changed files: 0 new errors (confirmed via `git stash` the pre-existing 2 `organizeImports` errors on `daemon.ts`/`session.ts` are unchanged; my new test file's own import-order error was auto-fixed with `biome check --write`, leaving only warning-level `noNonNullAssertion` consistent with the rest of this test suite's style).