### PR TITLE
fix(hooks): resolve #156 — adopt-loop silently adopted an auth-mismatched server after #150's own fix

### DIFF
--- a/.claude/helpers/control-start.cjs
+++ b/.claude/helpers/control-start.cjs
@@ -342,10 +342,16 @@ async function main() {
 
   // Adopt an already-listening server (e.g. started manually or by another session)
   // instead of spawning a duplicate that would bind port+1 and clobber control.json.
+  // probeStatus() returns the string 'unauthorized' (not null) for a server that
+  // answers but rejects our dashboard-token (added for the staleAuth check above,
+  // #150) — a non-empty string is truthy in JS, so `if (live)` alone would "adopt"
+  // an auth-mismatched server exactly like a healthy one, writing pid:0 (a string
+  // has no .pid) and leaving the mismatch in place instead of fixing it. Skip it
+  // and keep scanning for an actually-adoptable server on a later port instead.
   for (let delta = 0; delta <= 10; delta++) {
     const p = DEFAULT_PORT + delta;
     const live = await probeStatus(p);
-    if (live) {
+    if (live && live !== 'unauthorized') {
       writeStatus(live.pid || 0, p);
       if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] adopted running server on port ${p} (pid ${live.pid || 'unknown'})\n`);
       process.exit(0);

--- a/.gemini/helpers/control-start.cjs
+++ b/.gemini/helpers/control-start.cjs
@@ -342,10 +342,16 @@ async function main() {
 
   // Adopt an already-listening server (e.g. started manually or by another session)
   // instead of spawning a duplicate that would bind port+1 and clobber control.json.
+  // probeStatus() returns the string 'unauthorized' (not null) for a server that
+  // answers but rejects our dashboard-token (added for the staleAuth check above,
+  // #150) — a non-empty string is truthy in JS, so `if (live)` alone would "adopt"
+  // an auth-mismatched server exactly like a healthy one, writing pid:0 (a string
+  // has no .pid) and leaving the mismatch in place instead of fixing it. Skip it
+  // and keep scanning for an actually-adoptable server on a later port instead.
   for (let delta = 0; delta <= 10; delta++) {
     const p = DEFAULT_PORT + delta;
     const live = await probeStatus(p);
-    if (live) {
+    if (live && live !== 'unauthorized') {
       writeStatus(live.pid || 0, p);
       if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] adopted running server on port ${p} (pid ${live.pid || 'unknown'})\n`);
       process.exit(0);

--- a/packages/@monomind/cli/.claude/helpers/control-start.cjs
+++ b/packages/@monomind/cli/.claude/helpers/control-start.cjs
@@ -342,10 +342,16 @@ async function main() {
 
   // Adopt an already-listening server (e.g. started manually or by another session)
   // instead of spawning a duplicate that would bind port+1 and clobber control.json.
+  // probeStatus() returns the string 'unauthorized' (not null) for a server that
+  // answers but rejects our dashboard-token (added for the staleAuth check above,
+  // #150) — a non-empty string is truthy in JS, so `if (live)` alone would "adopt"
+  // an auth-mismatched server exactly like a healthy one, writing pid:0 (a string
+  // has no .pid) and leaving the mismatch in place instead of fixing it. Skip it
+  // and keep scanning for an actually-adoptable server on a later port instead.
   for (let delta = 0; delta <= 10; delta++) {
     const p = DEFAULT_PORT + delta;
     const live = await probeStatus(p);
-    if (live) {
+    if (live && live !== 'unauthorized') {
       writeStatus(live.pid || 0, p);
       if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] adopted running server on port ${p} (pid ${live.pid || 'unknown'})\n`);
       process.exit(0);

--- a/tests/hooks/control-start.test.mjs
+++ b/tests/hooks/control-start.test.mjs
@@ -140,6 +140,41 @@ describe('control-start: stale-token pairing self-heals instead of being trusted
       mock.kill('SIGTERM');
     }
   });
+
+  // Regression in the fix above: probeStatus() started returning the string
+  // 'unauthorized' instead of null for a 401 (needed so the "already
+  // running" check above could tell the two apart) — but the separate
+  // "adopt an already-listening server" loop in main() only checked
+  // `if (live)`, and a non-empty string is truthy in JS. So it "adopted" a
+  // 401-rejecting server exactly like a healthy one: `live.pid` is
+  // undefined on a string, so `writeStatus(live.pid || 0, p)` wrote pid:0
+  // into control.json and printed "adopted running server (pid unknown)" —
+  // silently leaving the mismatch in place instead of moving past it.
+  it('does not adopt a 401-rejecting server as if it were healthy', async () => {
+    const { spawn } = await import('child_process');
+    const port = isolatedPort();
+    const mockScript = path.join(tmpDir, 'mock401-adopt.cjs');
+    fs.writeFileSync(mockScript, `
+      const http = require('http');
+      const server = http.createServer((req, res) => {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Unauthorized: missing or invalid auth token' }));
+      });
+      server.listen(${port}, 'localhost', () => process.stderr.write('READY'));
+    `);
+    const mock = spawn(process.execPath, [mockScript], { stdio: ['ignore', 'ignore', 'pipe'] });
+    await new Promise((resolve) => mock.stderr.on('data', resolve));
+    try {
+      // No control.json written — main() reaches the adopt loop directly,
+      // which scans MONOMIND_CONTROL_PORT (== port here) for a live server.
+      const r = run({ cwd: tmpDir, env: { MONOMIND_CONTROL_PORT: String(port) } });
+      expect(r.stdout).not.toContain('adopted running server');
+      const data = readControlJson(tmpDir);
+      expect(data.pid).not.toBe(0);
+    } finally {
+      mock.kill('SIGTERM');
+    }
+  });
 });
 
 // ── not running ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #156.

\`#150\` changed \`probeStatus()\` to return the string \`'unauthorized'\` (instead of \`null\`) for a 401, so the "already running" check could distinguish "no server" from "server rejects our token". A separate adopt-loop wasn't updated to know about the new sentinel — its \`if (live)\` treated the truthy string \`'unauthorized'\` like a healthy response, silently "adopting" the mismatched server and writing \`pid: 0\` into \`control.json\`. Net effect: right after the staleAuth check correctly identifies a broken pairing, the adopt-loop immediately undoes the fix by re-accepting the same broken server.

## Fix

\`\`\`diff
- if (live) {
+ if (live && live !== 'unauthorized') {
\`\`\`

## Verification

Reproduced live with a mock 401 server before the fix (\`"adopted running server ... pid unknown"\`, \`control.json\` \`pid:0\`), applied the one-line fix, reproduced again — now correctly falls through to spawning a fresh server instead.

## Tests

- \`pnpm vitest run tests/hooks/control-start.test.mjs\` — 15/15 passing (14 existing + 1 new).
- New test mirrors the existing staleAuth test's pattern (separate spawned mock-server process — the harness's \`spawnSync\` call blocks its own event loop for the duration of the child it's waiting on, so an in-process mock can't respond to that very request).
- \`pnpm biome check\`: same pre-existing baseline pattern as prior PRs in this file (0 new issue categories — the 2 extra \`useNodejsImportProtocol\` infos are from the new test's \`require()\` calls matching the existing test's style).

## Files

Synced across all three tracked copies (root \`.claude/\`, \`.gemini/\`, \`packages/@monomind/cli/.claude/\`).