### PR TITLE
fix(orgrt): resolve #160 — org approve/deny/answer/gate never send the daemon auth credential

### DIFF
--- a/packages/@monomind/cli/src/__tests__/org-live-delivery-auth.test.ts
+++ b/packages/@monomind/cli/src/__tests__/org-live-delivery-auth.test.ts
@@ -1,0 +1,171 @@
+/**
+ * `org approve`/`org deny`/`org answer`/`org gate-approve` all have a "live"
+ * delivery path: if the org is currently hosted by a running daemon (found
+ * via the broker registry), they POST straight to that daemon's HTTP inbox
+ * instead of writing approvals.json/questions.json/gates.json and waiting
+ * for the daemon to notice the file changed on its next poll.
+ *
+ * That inbox server (orgrt/server.ts) requires an `x-monomind-cred` header
+ * on every POST endpoint, timing-safe-compared against a per-process
+ * credential shared through the broker registry entry. The `/api/xdeliver`
+ * call site attached it correctly, but `/api/answer-question`,
+ * `/api/set-approval`, and `/api/resolve-gate` never did — so every live
+ * delivery attempt 401'd and silently fell back to the offline file-write
+ * path. Slower (bounded by the daemon's poll interval, not instant), but
+ * easy to miss because the fallback always "worked" and only printed a
+ * warning.
+ *
+ * These tests spin up a bare HTTP server standing in for the daemon's inbox,
+ * register it in a temp broker registry with a credential, and assert the
+ * client actually sends that credential on each of the three fixed paths.
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  answerAction,
+  approveAction,
+  denyAction,
+  gateResolveAction,
+} from '../commands/org-observe.js';
+import { checkApproval } from '../orgrt/approvals.js';
+import { registerOrg, unregisterOrg } from '../orgrt/broker.js';
+import type { OrgDaemon } from '../orgrt/daemon.js';
+import { ORG_DIR } from '../orgrt/types.js';
+import type { CommandContext } from '../types.js';
+
+const CRED = 'test-credential-abc123';
+
+describe('org approve/deny/answer/gate — live delivery sends the auth credential', () => {
+  let cwd: string;
+  let brokerDir: string;
+  let server: http.Server;
+  let baseUrl: string;
+  let receivedHeaders: Record<string, string | string[] | undefined>[];
+  let prevBrokerDirEnv: string | undefined;
+
+  function ctx(args: string[]): CommandContext {
+    return { args, flags: { _: [] }, cwd, interactive: false };
+  }
+
+  beforeEach(async () => {
+    cwd = mkdtempSync(join(tmpdir(), 'org-live-cwd-'));
+    brokerDir = mkdtempSync(join(tmpdir(), 'org-live-broker-'));
+    prevBrokerDirEnv = process.env.MONOMIND_ORGRT_BROKER_DIR;
+    process.env.MONOMIND_ORGRT_BROKER_DIR = brokerDir;
+    receivedHeaders = [];
+
+    server = http.createServer((req, res) => {
+      receivedHeaders.push({ ...req.headers, url: req.url });
+      let body = '';
+      req.on('data', (c) => {
+        body += c;
+      });
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+    registerOrg('myorg', baseUrl, brokerDir, CRED);
+  });
+
+  afterEach(async () => {
+    unregisterOrg('myorg', brokerDir);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(brokerDir, { recursive: true, force: true });
+    if (prevBrokerDirEnv === undefined) delete process.env.MONOMIND_ORGRT_BROKER_DIR;
+    else process.env.MONOMIND_ORGRT_BROKER_DIR = prevBrokerDirEnv;
+  });
+
+  it('org approve sends x-monomind-cred to /api/set-approval', async () => {
+    const daemon = {
+      root: cwd,
+      approvals: new Map(),
+      approvalLocks: new Map(),
+      orgs: new Map(),
+    } as unknown as OrgDaemon;
+    await checkApproval(daemon, 'myorg', 'boss', 'Bash');
+
+    await approveAction(ctx(['myorg', 'boss', 'Bash']), 'myorg');
+
+    const hit = receivedHeaders.find((h) => h.url === '/api/set-approval');
+    expect(hit).toBeDefined();
+    expect(hit?.['x-monomind-cred']).toBe(CRED);
+  });
+
+  it('org deny sends x-monomind-cred to /api/set-approval', async () => {
+    const daemon = {
+      root: cwd,
+      approvals: new Map(),
+      approvalLocks: new Map(),
+      orgs: new Map(),
+    } as unknown as OrgDaemon;
+    await checkApproval(daemon, 'myorg', 'boss', 'WebFetch');
+
+    await denyAction(ctx(['myorg', 'boss', 'WebFetch']), 'myorg');
+
+    const hit = receivedHeaders.find((h) => h.url === '/api/set-approval');
+    expect(hit).toBeDefined();
+    expect(hit?.['x-monomind-cred']).toBe(CRED);
+  });
+
+  it('org answer sends x-monomind-cred to /api/answer-question', async () => {
+    const orgDir = join(cwd, ORG_DIR, 'myorg');
+    mkdirSync(orgDir, { recursive: true });
+    writeFileSync(
+      join(orgDir, 'questions.json'),
+      JSON.stringify({
+        questions: [
+          {
+            questionId: 'q1',
+            role: 'boss',
+            question: 'ok?',
+            answer: null,
+            ts: Date.now(),
+            answeredAt: null,
+          },
+        ],
+      }),
+    );
+
+    await answerAction(ctx(['myorg', 'q1', 'yes']), 'myorg');
+
+    const hit = receivedHeaders.find((h) => h.url === '/api/answer-question');
+    expect(hit).toBeDefined();
+    expect(hit?.['x-monomind-cred']).toBe(CRED);
+  });
+
+  it('org gate-approve sends x-monomind-cred to /api/resolve-gate', async () => {
+    const orgDir = join(cwd, ORG_DIR, 'myorg');
+    mkdirSync(orgDir, { recursive: true });
+    writeFileSync(
+      join(orgDir, 'gates.json'),
+      JSON.stringify({
+        gates: [
+          {
+            id: 'g1',
+            name: 'test gate',
+            description: 'test',
+            roleId: 'boss',
+            status: 'pending',
+            createdAt: Date.now(),
+          },
+        ],
+      }),
+    );
+
+    await gateResolveAction(ctx(['myorg', 'g1']), 'myorg', true);
+
+    const hit = receivedHeaders.find((h) => h.url === '/api/resolve-gate');
+    expect(hit).toBeDefined();
+    expect(hit?.['x-monomind-cred']).toBe(CRED);
+  });
+});

--- a/packages/@monomind/cli/src/commands/org-observe.ts
+++ b/packages/@monomind/cli/src/commands/org-observe.ts
@@ -336,12 +336,13 @@ export const answerAction = async (ctx: CommandContext, name: string): Promise<C
   if (q.answer !== null) return { success: false, message: `question "${questionId}" was already answered` };
 
   // Live path: the hosting daemon updates questions.json and pushes into the role's mailbox.
-  const { lookupOrg } = await import('../orgrt/broker.js');
+  const { lookupOrg, normalizeCredential } = await import('../orgrt/broker.js');
   const remote = lookupOrg(name);
   if (remote) {
+    const cred = normalizeCredential(remote.credential);
     try {
       const res = await fetch(`${remote.url}/api/answer-question`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        method: 'POST', headers: { 'Content-Type': 'application/json', ...(cred ? { 'x-monomind-cred': cred } : {}) },
         body: JSON.stringify({ org: name, role: q.role, questionId, answer }),
         signal: AbortSignal.timeout(10_000),
       });
@@ -659,12 +660,13 @@ export const flowAction = async (ctx: CommandContext, name: string): Promise<Com
 async function resolveApproval(ctx: CommandContext, name: string, role: string, action: string, approved: boolean): Promise<CommandResult> {
   const verb = approved ? 'approved' : 'denied';
 
-  const { lookupOrg } = await import('../orgrt/broker.js');
+  const { lookupOrg, normalizeCredential } = await import('../orgrt/broker.js');
   const remote = lookupOrg(name);
   if (remote) {
+    const cred = normalizeCredential(remote.credential);
     try {
       const res = await fetch(`${remote.url}/api/set-approval`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        method: 'POST', headers: { 'Content-Type': 'application/json', ...(cred ? { 'x-monomind-cred': cred } : {}) },
         body: JSON.stringify({ org: name, role, action, approved }),
         signal: AbortSignal.timeout(10_000),
       });
@@ -884,12 +886,13 @@ export const gateResolveAction = async (ctx: CommandContext, name: string, appro
   if (!gate) return { success: false, message: `gate "${gateId}" not found for org "${name}"` };
   if (gate.status !== 'pending') return { success: false, message: `gate "${gateId}" already resolved (${gate.status})` };
 
-  const { lookupOrg } = await import('../orgrt/broker.js');
+  const { lookupOrg, normalizeCredential } = await import('../orgrt/broker.js');
   const remote = lookupOrg(name);
   if (remote) {
+    const cred = normalizeCredential(remote.credential);
     try {
       const res = await fetch(`${remote.url}/api/resolve-gate`, {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        method: 'POST', headers: { 'Content-Type': 'application/json', ...(cred ? { 'x-monomind-cred': cred } : {}) },
         body: JSON.stringify({ org: name, gateId, approved, resolution }),
         signal: AbortSignal.timeout(10_000),
       });


### PR DESCRIPTION
Fixes #160.

## Summary
- `org approve`/`org deny`/`org answer`/`org gate-approve`/`gate-reject` all have a live-delivery fast path that POSTs to the hosting daemon's HTTP inbox instead of writing to disk and waiting for the daemon's next poll.
- The daemon's inbox server requires an `x-monomind-cred` header on every POST (timing-safe compared against a per-process credential shared via the broker registry).
- `/api/xdeliver` attached this header correctly; `/api/answer-question`, `/api/set-approval`, and `/api/resolve-gate` never did — so live delivery 401'd every time and silently fell back to the (working, but poll-bounded) offline queue. Only visible symptom: a "Live delivery rejected (unauthorized)" warning printed on every single approve/deny/answer/gate call.

## Fix
Attach `normalizeCredential(remote.credential)` as `x-monomind-cred` on all three broken call sites in `org-observe.ts`, mirroring the existing (correct) `xdeliver` pattern.

## Test plan
- [x] Added `org-live-delivery-auth.test.ts` — spins up a real HTTP server standing in for the daemon inbox, registers it in a temp broker registry with a known credential, and asserts each of the 4 live-delivery paths (approve, deny, answer, gate-approve) sends the credential header.
- [x] Verified the new tests fail against the pre-fix code (`git stash` the fix, rerun — all 4 fail with `undefined` instead of the credential) and pass after restoring the fix.
- [x] `tsc --noEmit` clean.
- [x] Full CLI test suite: same 21 pre-existing failing test files before and after this change (Windows-environment-specific, unrelated — `C:\tmp` path perms, shell echo behavior); no new failures introduced, +4 new passing tests.
- [x] `biome check` clean on both changed files (baseline already had 2 pre-existing import-order warnings in org-observe.ts, unrelated to this change and left untouched).

🤖 Generated with [monomind](https://github.com/monoes/monomind)