### PR TITLE
fix(resource-governor): resolve #163 — countSdkProcesses/reapOrphanedSdkProcesses spam console errors on Windows

### DIFF
--- a/packages/@monomind/cli/src/__tests__/resource-governor-windows.test.ts
+++ b/packages/@monomind/cli/src/__tests__/resource-governor-windows.test.ts
@@ -1,0 +1,56 @@
+/**
+ * countSdkProcesses() and reapOrphanedSdkProcesses() unconditionally shelled
+ * out to `pgrep`/`ps`, which don't exist on native Windows. The failure was
+ * caught (both wrapped the call in try/catch, returning 0), so nothing threw
+ * — but execSync inherits stderr by default, so every single call still
+ * printed "'pgrep' is not recognized as an internal or external command." to
+ * the console. Since countSdkProcesses runs on every lazy role spawn (via
+ * checkResources), a fresh org run with several roles kicking off at once
+ * printed a wall of these on Windows, on every single run.
+ *
+ * Fix: skip the shell-out entirely on win32 and return 0 (unknown), and
+ * silence inherited stderr on the platforms where the command does exist.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execSyncMock = vi.fn();
+vi.mock('node:child_process', () => ({ execSync: (...args: unknown[]) => execSyncMock(...args) }));
+
+let platformMock = vi.fn(() => 'win32');
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, platform: () => platformMock() };
+});
+
+describe('resource-governor — Windows never shells out to pgrep/ps', () => {
+  beforeEach(() => {
+    execSyncMock.mockReset();
+    vi.resetModules();
+  });
+
+  it('countSdkProcesses() on win32 returns 0 without calling execSync', async () => {
+    platformMock = vi.fn(() => 'win32');
+    const { countSdkProcesses } = await import('../utils/resource-governor.js');
+    expect(countSdkProcesses()).toBe(0);
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('reapOrphanedSdkProcesses() on win32 returns 0 without calling execSync', async () => {
+    platformMock = vi.fn(() => 'win32');
+    const { reapOrphanedSdkProcesses } = await import('../utils/resource-governor.js');
+    expect(reapOrphanedSdkProcesses(new Set())).toBe(0);
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('countSdkProcesses() on linux still calls execSync (pgrep) with stderr silenced', async () => {
+    platformMock = vi.fn(() => 'linux');
+    execSyncMock.mockReturnValue('123\n456\n');
+    const { countSdkProcesses } = await import('../utils/resource-governor.js');
+    const result = countSdkProcesses();
+    expect(result).toBe(2);
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+    const [cmd, opts] = execSyncMock.mock.calls[0] as [string, { stdio?: unknown[] }];
+    expect(cmd).toContain('pgrep');
+    expect(opts.stdio).toEqual(['ignore', 'pipe', 'ignore']);
+  });
+});

--- a/packages/@monomind/cli/src/utils/resource-governor.ts
+++ b/packages/@monomind/cli/src/utils/resource-governor.ts
@@ -52,10 +52,15 @@ export function getAvailableMemBytes(): number {
 }
 
 export function countSdkProcesses(): number {
+  // pgrep doesn't exist on native Windows — every call would fail (and, since
+  // execSync inherits stderr by default, print "'pgrep' is not recognized..."
+  // to the console on every lazy role spawn that hits this check). The
+  // concurrency cap it feeds just isn't enforceable there; treat as unknown.
+  if (platform() === 'win32') return 0;
   try {
     // Match only actual SDK agent binaries (have --output-format in argv),
     // not processes that merely reference the SDK package path.
-    const out = execSync('pgrep -f "claude-agent-sdk.*--output-format"', { encoding: 'utf8', timeout: 5000 });
+    const out = execSync('pgrep -f "claude-agent-sdk.*--output-format"', { encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] });
     return out.trim().split('\n').filter(Boolean).length;
   } catch { return 0; } // pgrep exits 1 when no matches
 }
@@ -110,8 +115,10 @@ export async function waitForCapacity(timeoutMs = 60_000): Promise<ResourceCheck
  *  @param ownerPid Only kill SDK processes whose parent is this PID.
  *    Prevents killing agents from OTHER monomind org processes. */
 export function reapOrphanedSdkProcesses(protectedPids: Set<number>, ownerPid?: number): number {
+  // ps doesn't exist on native Windows — same rationale as countSdkProcesses above.
+  if (platform() === 'win32') return 0;
   try {
-    const out = execSync('ps -eo pid,ppid,command', { encoding: 'utf8', timeout: 5000 });
+    const out = execSync('ps -eo pid,ppid,command', { encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'] });
     let reaped = 0;
     for (const line of out.split('\n')) {
       if (!line.includes('claude-agent-sdk') || !line.includes('--output-format')) continue;


### PR DESCRIPTION
Fixes #163.

## Summary
- `countSdkProcesses()` and `reapOrphanedSdkProcesses()` unconditionally shell out to `pgrep`/`ps`, which don't exist on native Windows.
- Both already handle the failure gracefully via try/catch → return 0, so nothing actually breaks functionally — but `execSync` inherits stderr by default, so the shell's "not recognized" error still prints to the console on every single call. Since `countSdkProcesses()` runs on every lazy role spawn (via `checkResources()` in `deliver()`), a multi-role org run on Windows prints a wall of these on every single run.

## Fix
- Guard both functions with `platform() === 'win32'` (mirrors the existing darwin `vm_stat` branch already in this file) and return 0 directly, skipping the shell-out entirely.
- Explicitly silence inherited stderr (`stdio: ['ignore','pipe','ignore']`) on the platforms where the commands do run, so a transient pgrep/ps failure there doesn't leak either.

## Test plan
- [x] Added `resource-governor-windows.test.ts` — mocks `node:os`'s `platform()` and `node:child_process`'s `execSync`, asserts neither function calls `execSync` at all on `win32`, and that the non-Windows path still calls `pgrep` with the stderr-silencing `stdio` option.
- [x] Verified all 3 new tests fail against the pre-fix code (`git stash` the fix, rerun) and pass with it.
- [x] `tsc --noEmit` clean.
- [x] `biome check` on both changed files matches the pre-existing baseline (2 pre-existing CRLF-related errors, 1 pre-existing unrelated `noGlobalIsNan` warning on an untouched line) — zero new issues introduced.

🤖 Generated with [monomind](https://github.com/monoes/monomind)