### PR TITLE
fix(orgrt): resolve #165 — stale approvals.json entries from a previous run survive forever

### DIFF
--- a/packages/@monomind/cli/src/__tests__/org-approval-gate.test.ts
+++ b/packages/@monomind/cli/src/__tests__/org-approval-gate.test.ts
@@ -21,12 +21,12 @@
  * so this is testable in isolation.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { gatedCanUseTool } from '../orgrt/session.js';
 import type { PolicyEngine, Decision } from '../orgrt/policy.js';
-import { checkApproval, setApproval } from '../orgrt/approvals.js';
+import { checkApproval, setApproval, clearApprovalsForFreshStart } from '../orgrt/approvals.js';
 import { approveAction, denyAction } from '../commands/org-observe.js';
 import { ORG_DIR } from '../orgrt/types.js';
 import type { OrgDaemon } from '../orgrt/daemon.js';
@@ -190,6 +190,64 @@ describe('checkApproval — role.policy.autoApproveTools bypasses the human-appr
     const daemon = daemonWithRole({ autoApproveTools: ['Bash'] });
     const result = await checkApproval(daemon, 'myorg', 'someone-else', 'Bash');
     expect(result).toBeNull();
+  });
+});
+
+describe('clearApprovalsForFreshStart — stale approvals from a previous run never resurface', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'org-clear-approvals-'));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('wipes the in-memory Map entry for the org', () => {
+    const daemon = { root: cwd, approvals: new Map([['myorg', [{ roleId: 'boss', action: 'Bash', question: 'q', ts: 1, approved: null }]]]), approvalLocks: new Map(), orgs: new Map() } as unknown as OrgDaemon;
+    clearApprovalsForFreshStart(daemon, 'myorg');
+    expect(daemon.approvals.get('myorg')).toBeUndefined();
+  });
+
+  it('resets an existing approvals.json to an empty array instead of leaving a stale pending entry', () => {
+    const orgDir = join(cwd, ORG_DIR, 'myorg');
+    mkdirSync(orgDir, { recursive: true });
+    const approvalsPath = join(orgDir, 'approvals.json');
+    writeFileSync(approvalsPath, JSON.stringify({
+      approvals: [{ roleId: 'ghost-role', action: 'Bash', question: 'Approve Bash tool call?', ts: 1, approved: null }],
+    }));
+    const daemon = { root: cwd, approvals: new Map(), approvalLocks: new Map(), orgs: new Map() } as unknown as OrgDaemon;
+
+    clearApprovalsForFreshStart(daemon, 'myorg');
+
+    const onDisk = JSON.parse(readFileSync(approvalsPath, 'utf8'));
+    expect(onDisk.approvals).toEqual([]);
+  });
+
+  it('is a no-op when no approvals.json exists yet — does not create one', () => {
+    const daemon = { root: cwd, approvals: new Map(), approvalLocks: new Map(), orgs: new Map() } as unknown as OrgDaemon;
+    clearApprovalsForFreshStart(daemon, 'myorg');
+    expect(existsSync(join(cwd, ORG_DIR, 'myorg', 'approvals.json'))).toBe(false);
+  });
+
+  it('a role that legitimately needs the same action approved in the new run gets a fresh, resolvable pending entry', async () => {
+    const orgDir = join(cwd, ORG_DIR, 'myorg');
+    mkdirSync(orgDir, { recursive: true });
+    writeFileSync(join(orgDir, 'approvals.json'), JSON.stringify({
+      approvals: [{ roleId: 'boss', action: 'Bash', question: 'Approve Bash tool call?', ts: 1, approved: null }],
+    }));
+    const daemon = { root: cwd, approvals: new Map(), approvalLocks: new Map(), orgs: new Map() } as unknown as OrgDaemon;
+    clearApprovalsForFreshStart(daemon, 'myorg');
+
+    // Simulates the new run's boss calling Bash again — must queue a fresh
+    // entry, not silently resolve against the wiped stale one.
+    const result = await checkApproval(daemon, 'myorg', 'boss', 'Bash');
+    expect(result).toBeNull();
+    expect(daemon.approvals.get('myorg')).toHaveLength(1);
+
+    const set = await setApproval(daemon, 'myorg', 'boss', 'Bash', true);
+    expect(set).toEqual({ ok: true }); // live delivery now finds it — no more "No pending approval found"
   });
 });
 

--- a/packages/@monomind/cli/src/orgrt/approvals.ts
+++ b/packages/@monomind/cli/src/orgrt/approvals.ts
@@ -1,10 +1,30 @@
 // packages/@monomind/cli/src/orgrt/approvals.ts
 // Extracted from daemon.ts — approval checking and setting for org tool calls.
 import { join } from 'node:path';
-import { mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { writeJsonFileAtomic } from '../utils/json-file.js';
 import { ORG_DIR } from './types.js';
 import type { OrgDaemon } from './daemon.js';
+
+/** Discard every approval — pending or resolved — left over from a previous
+ *  run. Call on a fresh (non-resume) startOrg.
+ *
+ *  approvals.json is keyed per-org, not per-run, and daemon.approvals is an
+ *  in-memory Map that starts empty in every fresh CLI process. A pending
+ *  approval queued by a role in a PREVIOUS run — never resolved before that
+ *  run ended — otherwise survives on disk forever: it looks "pending" to
+ *  anything reading the file directly (dashboard, status checks, even
+ *  `org approve`'s own live-delivery-then-fallback path), but the role that
+ *  requested it is gone and no live daemon will ever have a matching
+ *  in-memory record for it, so `org approve`'s live path always 404s with
+ *  "No pending approval found" and silently falls back to patching a ghost
+ *  entry nobody is listening for. A fresh start means every previous
+ *  approval is moot for this run. */
+export function clearApprovalsForFreshStart(daemon: OrgDaemon, org: string): void {
+  daemon.approvals.delete(org);
+  const approvalsPath = join(daemon.root, ORG_DIR, org, 'approvals.json');
+  if (existsSync(approvalsPath)) writeJsonFileAtomic(approvalsPath, { approvals: [] });
+}
 
 /** Check if an action requires human approval (beforeTool hook for guardrails). Returns
  *  the approval decision: true = approved, false = denied, null = pending (requires human input).

--- a/packages/@monomind/cli/src/orgrt/daemon.ts
+++ b/packages/@monomind/cli/src/orgrt/daemon.ts
@@ -439,6 +439,7 @@ export class OrgDaemon {
       }
     } else {
       this.abandoned.delete(name); // a previous run's missing roles say nothing about this one
+      approvalOps.clearApprovalsForFreshStart(this, name); // a previous run's approvals are moot for this one
       // random suffix: second-precision stamps collide across processes (two CLI
       // invocations in the same second would share a run dir and its bus.jsonl)
       run = `run-${new Date().toISOString().replace(/[-:T]/g, '').slice(0, 14)}-${Math.random().toString(36).slice(2, 6)}`;


### PR DESCRIPTION
Fixes #165.

## Summary
- `approvals.json` is keyed per-org, not per-run. `OrgDaemon#approvals` (the in-memory Map `checkApproval`/`setApproval` operate on) is fresh and empty in every new CLI process — nothing in `startOrg` ever clears or hydrates it against the persisted file.
- A pending approval queued by a role in a PREVIOUS run, never resolved before that run ended, survives on disk forever: it reads as "pending" to anything checking the file directly, but the current daemon has no matching in-memory record, so `org approve`/`deny`'s live-delivery path always fails with "No pending approval found" and silently falls back to patching a ghost entry nobody is listening for.
- Observed and root-caused live on a real 22-role org run — confirmed the failing live-delivery request reached the correct, currently-running daemon process (matching pid via broker lookup), and confirmed via `bus.jsonl` that the role in question never made the relevant tool call in the current run at all.

## Fix
- Extracted the discard logic into `approvalOps.clearApprovalsForFreshStart(daemon, org)` in `approvals.ts`, matching the existing `checkApproval`/`setApproval` extraction pattern.
- Called from `startOrg`'s non-resume branch, alongside the existing `this.abandoned.delete(name)` reset for the same underlying reason (a previous run's state doesn't carry over to a fresh one).
- `--resume` starts intentionally skip this — resuming is meant to continue exactly where the checkpoint left off.

## Test plan
- [x] Added 4 tests to `org-approval-gate.test.ts`: wipes the in-memory Map entry, resets an existing `approvals.json` to `[]`, no-ops (doesn't create a file) when none exists, and confirms a role that legitimately needs the same action re-approved in the new run gets a fresh entry that live-delivery `setApproval` can actually resolve.
- [x] Verified all 4 fail against the pre-fix code (`git stash` the fix, rerun) and pass with it.
- [x] `tsc --noEmit` clean.
- [x] `biome check` on all three changed files matches the pre-existing baseline exactly (6 errors / 12 warnings / 1 info, all pre-existing CRLF/unrelated) — zero new issues introduced.
- [x] Ran alongside the two related test files (`org-answer-questions-integrity.test.ts`, `org-live-delivery-auth.test.ts`) — all 29 tests pass together.

🤖 Generated with [monomind](https://github.com/monoes/monomind)