### PR TITLE
fix(orgrt): resolve #170 — org_complete never actually gated on human approval

### DIFF
--- a/packages/@monomind/cli/src/__tests__/org-approval-gate.test.ts
+++ b/packages/@monomind/cli/src/__tests__/org-approval-gate.test.ts
@@ -147,6 +147,65 @@ describe('checkApproval / setApproval — end-to-end state machine', () => {
   });
 });
 
+describe('checkApproval — org_complete arrives namespaced as mcp__org__org_complete and must still be gated', () => {
+  let cwd: string;
+  let daemon: OrgDaemon;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'org-mcp-prefix-'));
+    daemon = {
+      root: cwd,
+      approvals: new Map(),
+      approvalLocks: new Map(),
+      orgs: new Map(),
+    } as unknown as OrgDaemon;
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('queues mcp__org__org_complete as pending, not auto-approved', async () => {
+    // This is the exact string the SDK's canUseTool passes for a custom MCP
+    // tool from the 'org' server (createSdkMcpServer({ name: 'org', ... })) —
+    // NOT the bare 'org_complete' sensitiveActions was written against.
+    const result = await checkApproval(daemon, 'myorg', 'eng-director', 'mcp__org__org_complete');
+    expect(result).toBeNull(); // pending human approval — NOT auto-approved (was: true, unconditionally)
+    const pending = daemon.approvals.get('myorg');
+    expect(pending).toHaveLength(1);
+    // Stored under the clean name, so a human can resolve it with
+    // `monomind org approve myorg eng-director org_complete`, not the
+    // internal MCP-namespaced form.
+    expect(pending?.[0]).toMatchObject({ roleId: 'eng-director', action: 'org_complete', approved: null });
+  });
+
+  it('setApproval(true) for the normalized name resolves the mcp__org__-prefixed pending request', async () => {
+    await checkApproval(daemon, 'myorg', 'eng-director', 'mcp__org__org_complete');
+    const set = await setApproval(daemon, 'myorg', 'eng-director', 'org_complete', true);
+    expect(set).toEqual({ ok: true });
+
+    const result = await checkApproval(daemon, 'myorg', 'eng-director', 'mcp__org__org_complete');
+    expect(result).toBe(true);
+  });
+
+  it('a real SDK built-in tool (Bash) is unaffected — never had the mcp__org__ prefix to begin with', async () => {
+    const result = await checkApproval(daemon, 'myorg', 'boss', 'Bash');
+    expect(result).toBeNull();
+    expect(daemon.approvals.get('myorg')?.[0]).toMatchObject({ action: 'Bash' });
+  });
+
+  it('role.policy.autoApproveTools also matches against the normalized name', async () => {
+    const orgs = new Map([
+      ['myorg', { def: { roles: [{ id: 'eng-director', policy: { autoApproveTools: ['org_complete'] } }] }, bus: { emit: () => {} } }],
+    ]);
+    const trustedDaemon = { root: cwd, approvals: new Map(), approvalLocks: new Map(), orgs } as unknown as OrgDaemon;
+
+    const result = await checkApproval(trustedDaemon, 'myorg', 'eng-director', 'mcp__org__org_complete');
+    expect(result).toBe(true);
+    expect(trustedDaemon.approvals.get('myorg')).toBeUndefined(); // never queued at all
+  });
+});
+
 describe('checkApproval — role.policy.autoApproveTools bypasses the human-approval pause', () => {
   let cwd: string;
 

--- a/packages/@monomind/cli/src/orgrt/approvals.ts
+++ b/packages/@monomind/cli/src/orgrt/approvals.ts
@@ -6,12 +6,30 @@ import { writeJsonFileAtomic } from '../utils/json-file.js';
 import { ORG_DIR } from './types.js';
 import type { OrgDaemon } from './daemon.js';
 
+/** Custom org-runtime tools (org_complete, org_send, org_task, ...) are
+ *  registered as an SDK MCP server named 'org' (createSdkMcpServer({ name:
+ *  'org', ... }) in agent-runner.ts), so the SDK always presents them to
+ *  canUseTool/policy.decide under the namespaced form `mcp__org__<name>` —
+ *  unlike genuine SDK built-ins (Bash/WebFetch/WebSearch), which always
+ *  arrive as their bare name. checkApproval's sensitiveActions list (and any
+ *  role's policy.autoApproveTools) is written against the bare, human-facing
+ *  name — 'org_complete', not 'mcp__org__org_complete' — so without this,
+ *  'org_complete' NEVER matched and silently fell through to auto-approve
+ *  unconditionally on every single call. Of the four originally-intended
+ *  sensitive actions, the one whose approval mattered most (org_complete ends
+ *  the entire run) was the one that was never actually gated. */
+function normalizeToolAction(rawAction: string): string {
+  const prefix = 'mcp__org__';
+  return rawAction.startsWith(prefix) ? rawAction.slice(prefix.length) : rawAction;
+}
+
 /** Check if an action requires human approval (beforeTool hook for guardrails). Returns
  *  the approval decision: true = approved, false = denied, null = pending (requires human input).
  *
  *  R5: serialized per-org via withApprovalLock() — concurrent checkApproval and
  *  setApproval calls previously raced on this.approvals + approvals.json. */
-export function checkApproval(daemon: OrgDaemon, org: string, role: string, action: string): Promise<boolean | null> {
+export function checkApproval(daemon: OrgDaemon, org: string, role: string, rawAction: string): Promise<boolean | null> {
+  const action = normalizeToolAction(rawAction);
   return withApprovalLock(daemon, org, async () => {
     const pending = daemon.approvals.get(org) ?? [];
     const existing = pending.find(a => a.roleId === role && a.action === action);


### PR DESCRIPTION
Fixes #170.

## Summary
- `org_complete` is a custom tool registered via `createSdkMcpServer({ name: 'org', ... })`, so the SDK always presents it to `canUseTool`/`policy.decide` as `mcp__org__org_complete`, not its bare name.
- `checkApproval`'s `sensitiveActions` list checks for the literal string `'org_complete'`, which the namespaced form never matches — so the check silently falls through to auto-approve on every call, forever. `Bash`/`WebFetch`/`WebSearch` are genuine SDK built-ins (always unprefixed) and remain correctly gated; `org_complete` — the one action ending the entire run — was the one that never was.
- Confirmed live: `monoterminal-dev`'s boss called `org_complete("achieved")` immediately after teammates committed to next-day work, with the run's own summary showing only 4/7 of a multi-phase gate verified. No pending-approval record was ever created for the call.
- This is very likely the actual root cause of a pattern raised repeatedly this session — orgs ending far short of their stated goal. #158 already improved the idle-nudge/tool-description *wording* around this, which remains valuable, but it was the only defense (prompt-level, probabilistic). This restores the missing code-level backstop.

## Fix
Normalize the action name (strip a leading `mcp__org__`) at the top of `checkApproval`, before both the `autoApproveTools` and `sensitiveActions` checks, and store the pending record under the normalized name so `monomind org approve <org> <role> org_complete` still resolves it using the clean, human-facing name.

## Test plan
- [x] Added 4 tests: `mcp__org__org_complete` now queues as pending (not auto-approved), `setApproval` against the normalized name resolves the namespaced pending request, a genuine SDK built-in (`Bash`) is confirmed unaffected, and `role.policy.autoApproveTools` matches correctly against the normalized name too.
- [x] Verified the 2 tests exercising the actual bug fail against the pre-fix code (`git stash` the fix, rerun — `mcp__org__org_complete` returns `true` instead of `null`, matching the exact real-world incident) and pass with it. The other 2 pass regardless (as expected — they cover behavior the fix doesn't change).
- [x] `tsc --noEmit` clean.
- [x] `biome check` matches the pre-existing baseline exactly on both changed files (4 pre-existing CRLF errors, unrelated) — zero new issues.
- [x] Ran alongside `org-live-delivery-auth.test.ts`, `org-answer-questions-integrity.test.ts`, and `org-complete-scope-guidance.test.ts` (the related #158 fix) — all 32 tests pass together, no regressions.

🤖 Generated with [monomind](https://github.com/monoes/monomind)