### PR TITLE
fix(orgrt): resolve #173 — idle-nudge recovery requires a real tool call, not just any bus activity

### DIFF
--- a/packages/@monomind/cli/src/__tests__/idle-watchdog-nudge-reset.test.ts
+++ b/packages/@monomind/cli/src/__tests__/idle-watchdog-nudge-reset.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The idle watchdog's `nudges` counter was a pure lifetime total — it only
+ * ever incremented, never reset, even after a nudge got real activity back.
+ * MAX_IDLE_NUDGES (3) was meant to catch a boss that's genuinely hung/looping
+ * (every nudge goes unanswered), but as written it also caught a long-running,
+ * perfectly healthy org that simply went idle and recovered more than 3 times
+ * over its lifetime — e.g. a role periodically checking in on a slow
+ * background task (a 24h soak test, a long coverage run) between checkpoints.
+ *
+ * Observed live: monoterminal-dev was supervising an in-progress 24h soak
+ * test (survived its t=20 checkpoint, PID confirmed alive, next checkpoint
+ * due in ~1h). The org answered 3 separate idle-nudges with real, productive
+ * work each time (task-6 tests progressing, devops-lead posting checkpoint
+ * updates) — the boss never once appeared hung — but on the 4th idle spell
+ * the watchdog force-stopped the run anyway, citing "org idle again after 3
+ * nudges", killing the soak test process under 90 minutes into a 24h run.
+ *
+ * `resolvedIdleNudgeCount` is the extracted, pure piece of that decision
+ * (daemon.ts's watchdog tick calls it every time idleFor < idleMs) — testable
+ * without spinning up a real org, since the surrounding tick has side effects
+ * (bus events, mailbox pushes, stopOrg) that aren't worth mocking here.
+ */
+import { describe, expect, it } from 'vitest';
+import { resolvedIdleNudgeCount } from '../orgrt/daemon.js';
+
+describe('resolvedIdleNudgeCount — idle-watchdog nudge counter only tracks unresolved spells', () => {
+  it('leaves the counter untouched when there was no outstanding nudge (nudgedAt === 0)', () => {
+    expect(resolvedIdleNudgeCount(0, 2)).toBe(2);
+  });
+
+  it('resets the counter to 0 once an outstanding nudge is followed by real activity', () => {
+    expect(resolvedIdleNudgeCount(Date.now(), 1)).toBe(0);
+    expect(resolvedIdleNudgeCount(Date.now(), 3)).toBe(0);
+  });
+
+  it('replays the real incident: 3 separate idle spells, each recovered, must never trip the cumulative cap', () => {
+    const MAX_IDLE_NUDGES = 3;
+    let nudgedAt = 0;
+    let nudges = 0;
+
+    // Idle spell 1: nudge sent, then real activity arrives — resolved.
+    nudges++;
+    nudgedAt = Date.now();
+    nudges = resolvedIdleNudgeCount(nudgedAt, nudges);
+    nudgedAt = 0;
+    expect(nudges).toBe(0); // resolved — does NOT carry forward as 1
+
+    // Idle spell 2: same shape.
+    nudges++;
+    nudgedAt = Date.now();
+    nudges = resolvedIdleNudgeCount(nudgedAt, nudges);
+    nudgedAt = 0;
+    expect(nudges).toBe(0);
+
+    // Idle spell 3: same shape.
+    nudges++;
+    nudgedAt = Date.now();
+    nudges = resolvedIdleNudgeCount(nudgedAt, nudges);
+    nudgedAt = 0;
+    expect(nudges).toBe(0);
+
+    // A 4th idle spell must be treated as a fresh nudge, not a cap-trip —
+    // this is the exact check daemon.ts makes before calling idleStop().
+    expect(nudges).toBeLessThan(MAX_IDLE_NUDGES);
+  });
+
+  it('still lets a genuinely unresolved run of idle spells reach the cap (protection preserved)', () => {
+    const MAX_IDLE_NUDGES = 3;
+    let nudges = 0;
+    // Never recovers between nudges (nudgedAt stays nonzero, no reset call
+    // happens because the run never goes back below idleMs) — nudges simply
+    // increments every tick a fresh nudge is sent, same as production.
+    nudges++; // 1
+    nudges++; // 2
+    nudges++; // 3
+    expect(nudges).toBeGreaterThanOrEqual(MAX_IDLE_NUDGES); // caps correctly
+  });
+});

--- a/packages/@monomind/cli/src/__tests__/idle-watchdog-nudge-reset.test.ts
+++ b/packages/@monomind/cli/src/__tests__/idle-watchdog-nudge-reset.test.ts
@@ -15,6 +15,17 @@
  * the watchdog force-stopped the run anyway, citing "org idle again after 3
  * nudges", killing the soak test process under 90 minutes into a 24h run.
  *
+ * Fixing THAT exposed a second, subtler bug: resetting the counter on ANY
+ * bus activity (including a bare, content-free chat reply with zero tool
+ * calls) let a boss that's genuinely out of ideas loop forever making zero
+ * progress. Observed live: a boss answered four consecutive 10-minute idle
+ * nudges with one-line acknowledgments ("✓ Complete", "✓", "Session
+ * complete.") and made zero tool calls across all of them — no org_send, no
+ * org_task, nothing — yet the org never got flagged, because every trivial
+ * reply reset the cumulative cap meant to catch exactly this. The fix
+ * requires a REAL tool call (lastToolActivity) after the nudge was sent, not
+ * just any bus event, before treating an idle spell as resolved.
+ *
  * `resolvedIdleNudgeCount` is the extracted, pure piece of that decision
  * (daemon.ts's watchdog tick calls it every time idleFor < idleMs) — testable
  * without spinning up a real org, since the surrounding tick has side effects
@@ -25,43 +36,60 @@ import { resolvedIdleNudgeCount } from '../orgrt/daemon.js';
 
 describe('resolvedIdleNudgeCount — idle-watchdog nudge counter only tracks unresolved spells', () => {
   it('leaves the counter untouched when there was no outstanding nudge (nudgedAt === 0)', () => {
-    expect(resolvedIdleNudgeCount(0, 2)).toBe(2);
+    expect(resolvedIdleNudgeCount(0, 2, 0)).toBe(2);
   });
 
-  it('resets the counter to 0 once an outstanding nudge is followed by real activity', () => {
-    expect(resolvedIdleNudgeCount(Date.now(), 1)).toBe(0);
-    expect(resolvedIdleNudgeCount(Date.now(), 3)).toBe(0);
+  it('resets the counter to 0 once an outstanding nudge is followed by a real tool call', () => {
+    const nudgedAt = Date.now();
+    const toolActivityAfter = nudgedAt + 100;
+    expect(resolvedIdleNudgeCount(nudgedAt, 1, toolActivityAfter)).toBe(0);
+    expect(resolvedIdleNudgeCount(nudgedAt, 3, toolActivityAfter)).toBe(0);
   });
 
-  it('replays the real incident: 3 separate idle spells, each recovered, must never trip the cumulative cap', () => {
+  it('does NOT reset when the nudge is outstanding but no tool call has happened since (the trivial-ack bug)', () => {
+    const nudgedAt = Date.now();
+    // lastToolActivity is 0 (never happened) or predates the nudge — a bare
+    // chat-only reply with no tool calls, exactly the observed incident.
+    expect(resolvedIdleNudgeCount(nudgedAt, 2, 0)).toBe(2);
+    expect(resolvedIdleNudgeCount(nudgedAt, 2, nudgedAt - 5000)).toBe(2);
+  });
+
+  it('replays the real 24h-soak-test incident: 3 separate idle spells, each recovered with real tool activity, must never trip the cumulative cap', () => {
     const MAX_IDLE_NUDGES = 3;
     let nudgedAt = 0;
     let nudges = 0;
 
-    // Idle spell 1: nudge sent, then real activity arrives — resolved.
-    nudges++;
-    nudgedAt = Date.now();
-    nudges = resolvedIdleNudgeCount(nudgedAt, nudges);
-    nudgedAt = 0;
-    expect(nudges).toBe(0); // resolved — does NOT carry forward as 1
-
-    // Idle spell 2: same shape.
-    nudges++;
-    nudgedAt = Date.now();
-    nudges = resolvedIdleNudgeCount(nudgedAt, nudges);
-    nudgedAt = 0;
-    expect(nudges).toBe(0);
-
-    // Idle spell 3: same shape.
-    nudges++;
-    nudgedAt = Date.now();
-    nudges = resolvedIdleNudgeCount(nudgedAt, nudges);
-    nudgedAt = 0;
-    expect(nudges).toBe(0);
+    for (let i = 0; i < 3; i++) {
+      nudges++;
+      nudgedAt = Date.now();
+      const toolActivityAfter = nudgedAt + 50; // devops-lead posts a real checkpoint update
+      nudges = resolvedIdleNudgeCount(nudgedAt, nudges, toolActivityAfter);
+      nudgedAt = 0;
+      expect(nudges).toBe(0); // resolved — does NOT carry forward
+    }
 
     // A 4th idle spell must be treated as a fresh nudge, not a cap-trip —
     // this is the exact check daemon.ts makes before calling idleStop().
     expect(nudges).toBeLessThan(MAX_IDLE_NUDGES);
+  });
+
+  it('replays the trivial-ack incident: 3 separate idle spells, each "answered" with zero tool calls, must reach the cumulative cap', () => {
+    const MAX_IDLE_NUDGES = 3;
+    let nudgedAt = 0;
+    let nudges = 0;
+    const lastToolActivity = 0; // boss never calls a tool the entire run
+
+    for (let i = 0; i < 3; i++) {
+      nudges++;
+      nudgedAt = Date.now();
+      // Recovery check runs, but no tool call happened since nudgedAt — this
+      // idle spell is NOT resolved, nudges carries forward as-is.
+      nudges = resolvedIdleNudgeCount(nudgedAt, nudges, lastToolActivity);
+      nudgedAt = 0;
+    }
+
+    expect(nudges).toBe(3);
+    expect(nudges).toBeGreaterThanOrEqual(MAX_IDLE_NUDGES); // caps correctly — this is what was NOT happening live
   });
 
   it('still lets a genuinely unresolved run of idle spells reach the cap (protection preserved)', () => {

--- a/packages/@monomind/cli/src/orgrt/daemon.ts
+++ b/packages/@monomind/cli/src/orgrt/daemon.ts
@@ -164,23 +164,34 @@ export function roleTokenBudget(role: OrgRole, def: OrgDef): number {
   );
 }
 
-/** Idle watchdog's per-tick recovery check: given the previous nudge timestamp
- *  and the cumulative nudge count, returns the nudge count that should carry
- *  forward now that fresh activity means the org is no longer idle.
+/** Idle watchdog's per-tick recovery check: given the previous nudge timestamp,
+ *  the cumulative nudge count, and the timestamp of the most recent real tool
+ *  call, returns the nudge count that should carry forward now that fresh
+ *  activity means the org is no longer idle.
  *
- *  `nudgedAt !== 0` means we're recovering from an outstanding nudge — real
- *  activity arrived, so that nudge was answered, not ignored, and this idle
- *  spell is resolved. Resetting the counter here means it only ever tracks
- *  UNRESOLVED idle spells in a row, not a lifetime total — a long-running org
- *  that goes idle and recovers any number of times (e.g. periodic checkpoints
- *  on a slow background task) is never punished for having had several
- *  separate, healthy idle spells over its lifetime. Before this fix `nudges`
- *  only ever incremented, so a run that answered every single nudge with real
- *  work still hit the "org idle again after 3 nudges" cap and got
- *  force-stopped on its 4th idle spell — observed live killing an in-progress
- *  24h soak test under 90 minutes in. */
-export function resolvedIdleNudgeCount(nudgedAt: number, nudges: number): number {
-  return nudgedAt !== 0 ? 0 : nudges;
+ *  `nudgedAt !== 0` means we're recovering from an outstanding nudge. Resetting
+ *  the counter here means it only ever tracks UNRESOLVED idle spells in a row,
+ *  not a lifetime total — a long-running org that goes idle and recovers any
+ *  number of times (e.g. periodic checkpoints on a slow background task) is
+ *  never punished for having had several separate, healthy idle spells over
+ *  its lifetime. Before this existed, `nudges` only ever incremented, so a run
+ *  that answered every single nudge with real work still hit the "org idle
+ *  again after 3 nudges" cap and got force-stopped on its 4th idle spell —
+ *  observed live killing an in-progress 24h soak test under 90 minutes in.
+ *
+ *  But "recovering" must mean genuine forward progress, not just any bus
+ *  event — a bare, content-free reply to the nudge (a boss that answers with
+ *  "✓ Complete" and calls no tools at all) still updates lastActivity, so the
+ *  org isn't flagged as silent, but it accomplishes nothing: nobody outside
+ *  the boss's own turn ever sees it, since role coordination only happens via
+ *  tool calls (org_send, org_task, ...). Requiring `lastToolActivity >=
+ *  nudgedAt` — a real tool call happened AFTER this nudge was sent — closes
+ *  that gap: observed live, a boss stuck responding to four consecutive
+ *  10-minute nudges with one-line acknowledgments and zero tool calls looped
+ *  indefinitely making no progress, because every trivial reply reset the cap
+ *  that was supposed to catch exactly this. */
+export function resolvedIdleNudgeCount(nudgedAt: number, nudges: number, lastToolActivity: number): number {
+  return nudgedAt !== 0 && lastToolActivity >= nudgedAt ? 0 : nudges;
 }
 
 /** Bounded ring buffer for agent terminal scrollback. */
@@ -550,6 +561,16 @@ export class OrgDaemon {
     const MAX_COLLECTED = 1000;
     const collected: BusEvent[] = [];
     let lastActivity = Date.now();
+    // Separate from lastActivity: only real tool calls (org_send, org_task,
+    // Bash, ...) count here, not status pings or chat-only turns. The idle
+    // watchdog's nudge-recovery check (resolvedIdleNudgeCount) uses this to
+    // tell genuine forward progress apart from a boss that "answers" a nudge
+    // with a bare acknowledgment ("✓ Complete") and does nothing — a
+    // content-free reply still updates lastActivity (so the org isn't
+    // flagged as silent), but must not reset the cumulative nudge cap, or a
+    // boss that's genuinely out of ideas can loop forever making zero
+    // progress without ever tripping the watchdog.
+    let lastToolActivity = 0;
     bus.subscribe((e) => {
       const slim: BusEvent =
         e.data?.content != null ? { ...e, data: { ...e.data, content: undefined } } : e;
@@ -558,6 +579,7 @@ export class OrgDaemon {
       // The watchdog's own nudge event must not count as org activity, or a
       // hung boss would never trip the "nudge produced no activity" stop.
       if (e.reason !== 'idle-nudge') lastActivity = Date.now();
+      if (e.type === 'tool') lastToolActivity = Date.now();
       // org_complete IS the end of the run — self-stop instead of sitting
       // "running" forever after a recorded outcome. Deferred (unref'd) so the
       // tool call's receipt reaches the boss and its final turn text still
@@ -1156,7 +1178,7 @@ export class OrgDaemon {
           if (pendingGates.length > 0) return;
           const idleFor = Date.now() - lastActivity;
           if (idleFor < idleMs) {
-            nudges = resolvedIdleNudgeCount(nudgedAt, nudges);
+            nudges = resolvedIdleNudgeCount(nudgedAt, nudges, lastToolActivity);
             nudgedAt = 0;
             return;
           }

--- a/packages/@monomind/cli/src/orgrt/daemon.ts
+++ b/packages/@monomind/cli/src/orgrt/daemon.ts
@@ -164,6 +164,25 @@ export function roleTokenBudget(role: OrgRole, def: OrgDef): number {
   );
 }
 
+/** Idle watchdog's per-tick recovery check: given the previous nudge timestamp
+ *  and the cumulative nudge count, returns the nudge count that should carry
+ *  forward now that fresh activity means the org is no longer idle.
+ *
+ *  `nudgedAt !== 0` means we're recovering from an outstanding nudge — real
+ *  activity arrived, so that nudge was answered, not ignored, and this idle
+ *  spell is resolved. Resetting the counter here means it only ever tracks
+ *  UNRESOLVED idle spells in a row, not a lifetime total — a long-running org
+ *  that goes idle and recovers any number of times (e.g. periodic checkpoints
+ *  on a slow background task) is never punished for having had several
+ *  separate, healthy idle spells over its lifetime. Before this fix `nudges`
+ *  only ever incremented, so a run that answered every single nudge with real
+ *  work still hit the "org idle again after 3 nudges" cap and got
+ *  force-stopped on its 4th idle spell — observed live killing an in-progress
+ *  24h soak test under 90 minutes in. */
+export function resolvedIdleNudgeCount(nudgedAt: number, nudges: number): number {
+  return nudgedAt !== 0 ? 0 : nudges;
+}
+
 /** Bounded ring buffer for agent terminal scrollback. */
 export class ScrollbackBuffer {
   private lines: string[] = [];
@@ -1115,8 +1134,9 @@ export class OrgDaemon {
     // org_complete) produces no bus events, and every agent just waits. After
     // idle_minutes of silence, nudge the boss to complete or reassign; if the
     // nudge itself produces no activity (boss hung/crashed), or the org keeps
-    // going idle after MAX_IDLE_NUDGES nudges, stop the run instead of letting
-    // it freeze forever. idle_minutes: 0 disables.
+    // going idle after MAX_IDLE_NUDGES nudges in a row without ever recovering
+    // (see resolvedIdleNudgeCount), stop the run instead of letting it freeze
+    // forever. idle_minutes: 0 disables.
     const idleMs = (def.run_config.idle_minutes ?? 10) * 60_000;
     if (idleMs > 0) {
       const MAX_IDLE_NUDGES = 3;
@@ -1136,6 +1156,7 @@ export class OrgDaemon {
           if (pendingGates.length > 0) return;
           const idleFor = Date.now() - lastActivity;
           if (idleFor < idleMs) {
+            nudges = resolvedIdleNudgeCount(nudgedAt, nudges);
             nudgedAt = 0;
             return;
           }


### PR DESCRIPTION
Fixes #173.

**Note:** this branch stacks on #169 (cherry-picked as the first commit here, since #169 isn't merged yet) — GitHub will show both commits until #169 lands. The actual new work is the second commit only.

## Summary
- Follow-up to #168/#169. Fixing the idle-watchdog's cumulative nudge counter exposed a second, related bug: `resolvedIdleNudgeCount` reset the counter on ANY bus activity following a nudge, including a bare, content-free chat reply with zero tool calls.
- Observed live, after #169 was already deployed: a boss answered 4 consecutive idle-nudges with one-line acknowledgments ("✓ Complete", "✓", "Session complete.") and made zero tool calls across all of them (confirmed via `bus.jsonl` — 0 'tool' events in the 40+ minute window). The org sat completely stalled and was never flagged, since coordination in this system only happens via tool calls (`org_send`, `org_task`, ...) — a tool-free reply accomplishes nothing visible to anyone else, but still reset the cap meant to catch exactly this.

## Fix
Track a new `lastToolActivity` timestamp (updated only on `e.type === 'tool'` events) alongside `lastActivity`. `resolvedIdleNudgeCount` now takes a third parameter and requires `lastToolActivity >= nudgedAt` before resetting the counter — a real tool call must have happened after this specific nudge. Genuine recovery (any role doing real work) always involves at least one tool call, so #169's legitimate use case is unaffected; only a hollow acknowledgment now correctly fails to reset the cap.

## Test plan
- [x] Updated `idle-watchdog-nudge-reset.test.ts`: existing tests updated for the new 3-arg signature, plus 2 new tests — a trivial-ack reply (no tool activity since the nudge) does NOT reset the counter, and a replay of the exact live trivial-ack incident (3 tool-free acknowledgments) correctly reaches the cumulative cap.
- [x] Verified the 2 new tests fail against the pre-fix (2-arg) code (`git stash` the daemon.ts change, rerun) and pass with the fix.
- [x] `tsc --noEmit` clean.
- [x] `biome check` matches the pre-existing baseline exactly on `daemon.ts` (2 pre-existing CRLF errors, unrelated) — zero new issues.
- [x] Ran alongside `org-complete-scope-guidance.test.ts` and `org-stop-timeout-roster.test.ts` — all 11 tests pass together.

🤖 Generated with [monomind](https://github.com/monoes/monomind)