### PR TITLE
feat(orgrt): resolve #175 — org_task_block lets a task wait on a real-world time without idle-nudge spam

### DIFF
--- a/packages/@monomind/cli/src/__tests__/dag-block-task.test.ts
+++ b/packages/@monomind/cli/src/__tests__/dag-block-task.test.ts
@@ -1,0 +1,79 @@
+/**
+ * dagBlockTask (decisions.ts) is the daemon-facing wiring behind the
+ * org_task_block tool — see task-dag-block.test.ts for the underlying
+ * TaskDag.block() behavior this delegates to. These tests exercise the
+ * full daemon-facing shape: bus event emission, error JSON on bad input,
+ * and the "org not running" guard shared by every other dagXxx function.
+ */
+import { describe, expect, it } from 'vitest';
+import type { OrgDaemon, RunningOrg } from '../orgrt/daemon.js';
+import { dagBlockTask } from '../orgrt/decisions.js';
+import { TaskDag } from '../orgrt/task-dag.js';
+import type { BusEvent } from '../orgrt/types.js';
+
+function fakeDaemon(taskDag?: TaskDag): { daemon: OrgDaemon; events: BusEvent[] } {
+  const events: BusEvent[] = [];
+  const running = taskDag
+    ? ({ taskDag, bus: { emit: (e: BusEvent) => events.push(e) } } as unknown as RunningOrg)
+    : undefined;
+  const orgs = new Map(running ? [['myorg', running]] : []);
+  const daemon = { orgs } as unknown as OrgDaemon;
+  return { daemon, events };
+}
+
+describe('dagBlockTask', () => {
+  it('blocks a running task and emits a task-blocked bus event', () => {
+    const dag = new TaskDag();
+    const t = dag.add('Analyze soak evidence', 'performance-engineer');
+    dag.markRunning(t.id);
+    const { daemon, events } = fakeDaemon(dag);
+
+    const result = JSON.parse(
+      dagBlockTask(
+        daemon,
+        'myorg',
+        'performance-engineer',
+        t.id,
+        '2026-08-19T09:00:00Z',
+        'Waiting on soak test',
+      ),
+    );
+
+    expect(result.blocked).toBe(t.id);
+    expect(result.status).toBe('blocked');
+    expect(dag.get(t.id)?.status).toBe('blocked');
+    expect(dag.get(t.id)?.blockedReason).toBe('Waiting on soak test');
+
+    const ev = events.find((e) => e.reason === 'task-blocked');
+    expect(ev).toBeDefined();
+    expect((ev?.data as { taskId?: string })?.taskId).toBe(t.id);
+  });
+
+  it('returns an error JSON, not a throw, for an invalid ISO date', () => {
+    const dag = new TaskDag();
+    const t = dag.add('x', 'a');
+    dag.markRunning(t.id);
+    const { daemon } = fakeDaemon(dag);
+
+    const result = JSON.parse(dagBlockTask(daemon, 'myorg', 'a', t.id, 'not-a-date'));
+    expect(result.error).toMatch(/not a valid ISO date/);
+    expect(dag.get(t.id)?.status).toBe('running'); // unchanged
+  });
+
+  it('returns an error JSON for a task that is not running', () => {
+    const dag = new TaskDag();
+    const t = dag.add('x', 'a'); // status: 'ready', never marked running
+    const { daemon } = fakeDaemon(dag);
+
+    const result = JSON.parse(dagBlockTask(daemon, 'myorg', 'a', t.id, '2026-08-19T09:00:00Z'));
+    expect(result.error).toMatch(/must be 'running' to block/);
+  });
+
+  it('returns "org not running" when the org has no live taskDag', () => {
+    const { daemon } = fakeDaemon(undefined);
+    const result = JSON.parse(
+      dagBlockTask(daemon, 'ghost-org', 'a', 'task-1', '2026-08-19T09:00:00Z'),
+    );
+    expect(result.error).toBe('org not running');
+  });
+});

--- a/packages/@monomind/cli/src/__tests__/task-dag-block.test.ts
+++ b/packages/@monomind/cli/src/__tests__/task-dag-block.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The org task model had no way to represent "this task can't proceed until a
+ * specific real-world time" — only dependency-based blocking (deps not done
+ * yet). Observed live on a real, long-running org: a role explicitly said in
+ * chat "task-4 status='running' represents standby/blocked state (no
+ * 'blocked' status in org task model)" while waiting on a scheduled 24h soak
+ * test. With no way to express that, the idle watchdog nudged the boss every
+ * ~10-20 minutes for hours, each nudge a real LLM turn spent re-confirming
+ * "still waiting, nothing changed" — pure wasted cost for zero new
+ * information, only reset the idle-nudge counter without ever actually
+ * enabling anyone to skip the exchange.
+ *
+ * `org_task_block` (this file) adds a real 'blocked' status with a
+ * blockedUntil timestamp; the idle watchdog (daemon.ts) treats an active
+ * block the same as a pending decision gate — skip nudging entirely — and
+ * auto-resumes (re-dispatches) the task the moment the time passes.
+ */
+import { describe, expect, it } from 'vitest';
+import { TaskDag } from '../orgrt/task-dag.js';
+
+describe('TaskDag — block/unblockExpired/hasActiveBlock', () => {
+  it('blocks a running task with a future blockedUntil and reason', () => {
+    const dag = new TaskDag();
+    const t = dag.add('Analyze soak test evidence', 'performance-engineer');
+    dag.markRunning(t.id);
+
+    const future = Date.now() + 60_000;
+    const blocked = dag.block(t.id, future, 'Waiting on 24h soak test, due Friday');
+
+    expect(blocked.status).toBe('blocked');
+    expect(blocked.blockedUntil).toBe(future);
+    expect(blocked.blockedReason).toBe('Waiting on 24h soak test, due Friday');
+  });
+
+  it('refuses to block a task that is not currently running', () => {
+    const dag = new TaskDag();
+    const t = dag.add('Design phase 2', 'principal-architect'); // status: 'ready'
+    expect(() => dag.block(t.id, Date.now() + 60_000)).toThrow(/must be 'running' to block/);
+  });
+
+  it('refuses a blockedUntil that is not in the future', () => {
+    const dag = new TaskDag();
+    const t = dag.add('x', 'a');
+    dag.markRunning(t.id);
+    expect(() => dag.block(t.id, Date.now() - 1000)).toThrow(/must be in the future/);
+  });
+
+  it('refuses to block a nonexistent task', () => {
+    const dag = new TaskDag();
+    expect(() => dag.block('task-999', Date.now() + 60_000)).toThrow(/not found/);
+  });
+
+  it('hasActiveBlock is true while blockedUntil is in the future, false once passed', () => {
+    const dag = new TaskDag();
+    const t = dag.add('x', 'a');
+    dag.markRunning(t.id);
+    dag.block(t.id, Date.now() + 60_000);
+
+    expect(dag.hasActiveBlock(Date.now())).toBe(true);
+    expect(dag.hasActiveBlock(Date.now() + 120_000)).toBe(false); // as-of a later "now", the block has lapsed
+  });
+
+  it('hasActiveBlock is false when nothing is blocked', () => {
+    const dag = new TaskDag();
+    dag.add('x', 'a');
+    expect(dag.hasActiveBlock(Date.now())).toBe(false);
+  });
+
+  it('unblockExpired transitions an expired block back to running and clears blockedUntil/reason', () => {
+    const dag = new TaskDag();
+    const t = dag.add('x', 'a');
+    dag.markRunning(t.id);
+    dag.block(t.id, Date.now() + 1, 'brief wait');
+
+    const unblocked = dag.unblockExpired(Date.now() + 100); // "now" is past the block time
+    expect(unblocked).toHaveLength(1);
+    expect(unblocked[0].id).toBe(t.id);
+    expect(unblocked[0].status).toBe('running');
+    expect(unblocked[0].blockedUntil).toBeUndefined();
+    expect(unblocked[0].blockedReason).toBeUndefined();
+  });
+
+  it('unblockExpired leaves a still-future block untouched', () => {
+    const dag = new TaskDag();
+    const t = dag.add('x', 'a');
+    dag.markRunning(t.id);
+    dag.block(t.id, Date.now() + 60_000);
+
+    const unblocked = dag.unblockExpired(Date.now());
+    expect(unblocked).toHaveLength(0);
+    expect(dag.get(t.id)?.status).toBe('blocked');
+  });
+
+  it('unblockExpired is a no-op when nothing is blocked', () => {
+    const dag = new TaskDag();
+    dag.add('x', 'a');
+    expect(dag.unblockExpired(Date.now())).toEqual([]);
+  });
+
+  it('downstream tasks depending on a blocked task stay pending — blocked is not satisfied', () => {
+    const dag = new TaskDag();
+    const parent = dag.add('parent', 'a');
+    dag.markRunning(parent.id);
+    dag.block(parent.id, Date.now() + 60_000);
+    const child = dag.add('child', 'b', [parent.id]);
+
+    expect(child.status).toBe('pending'); // NOT 'ready' — blocked ≠ satisfied
+  });
+});

--- a/packages/@monomind/cli/src/orgrt/daemon.ts
+++ b/packages/@monomind/cli/src/orgrt/daemon.ts
@@ -881,6 +881,9 @@ export class OrgDaemon {
         cancelTask: (r: string, taskId: string, reason?: string) => {
           return this.dagCancelTask(name, r, taskId, reason);
         },
+        blockTask: (r: string, taskId: string, untilIso: string, reason?: string) => {
+          return this.dagBlockTask(name, r, taskId, untilIso, reason);
+        },
         planGraph: (r: string, specs: decisionOps.PlanTaskSpec[]) => {
           return this.dagPlanGraph(name, r, specs);
         },
@@ -1176,6 +1179,27 @@ export class OrgDaemon {
           // A pending gate means the org is legitimately waiting for human input
           const pendingGates = this.readGates(name).gates.filter((g) => g.status === 'pending');
           if (pendingGates.length > 0) return;
+          // Auto-resume any task whose org_task_block time has passed: flip it
+          // back to 'running' and re-push it into the assignee's mailbox, same
+          // as a fresh dispatch. This IS real activity, so fall through to the
+          // normal idleFor check below rather than returning early — an
+          // unblocked task should reset the idle clock, not just silently
+          // update state nobody notices until the next nudge.
+          const unblocked = running.taskDag?.unblockExpired(Date.now()) ?? [];
+          for (const task of unblocked) {
+            const agent = running.agents.get(task.assignee);
+            if (agent && !agent.mailbox.isClosed) {
+              agent.mailbox.push(`[task:${task.id}] Block expired — resuming: ${task.title}`);
+            }
+            bus.emit({
+              type: 'status', from: 'dag', reason: 'task-unblocked',
+              msg: `task ${task.id} block expired — resumed and re-dispatched to ${task.assignee}`,
+              data: { taskId: task.id, assignee: task.assignee },
+            });
+          }
+          // A task blocked on a real-world time still in the future is
+          // legitimate waiting, same as a pending gate — don't nudge about it.
+          if (running.taskDag?.hasActiveBlock(Date.now())) return;
           const idleFor = Date.now() - lastActivity;
           if (idleFor < idleMs) {
             nudges = resolvedIdleNudgeCount(nudgedAt, nudges, lastToolActivity);
@@ -1620,6 +1644,9 @@ export class OrgDaemon {
   }
   private dagCancelTask(org: string, role: string, taskId: string, reason?: string): string {
     return decisionOps.dagCancelTask(this, org, role, taskId, reason);
+  }
+  private dagBlockTask(org: string, role: string, taskId: string, untilIso: string, reason?: string): string {
+    return decisionOps.dagBlockTask(this, org, role, taskId, untilIso, reason);
   }
   private dagPlanGraph(org: string, role: string, specs: decisionOps.PlanTaskSpec[]): string {
     return decisionOps.dagPlanGraph(this, org, role, specs);

--- a/packages/@monomind/cli/src/orgrt/decisions.ts
+++ b/packages/@monomind/cli/src/orgrt/decisions.ts
@@ -212,6 +212,27 @@ export function dagCancelTask(
   }
 }
 
+export function dagBlockTask(
+  daemon: OrgDaemon, org: string, role: string,
+  taskId: string, untilIso: string, reason?: string,
+): string {
+  const running = daemon.orgs.get(org);
+  if (!running?.taskDag) return JSON.stringify({ error: 'org not running' });
+  const untilMs = Date.parse(untilIso);
+  if (Number.isNaN(untilMs)) return JSON.stringify({ error: `"${untilIso}" is not a valid ISO date/time` });
+  try {
+    const task = running.taskDag.block(taskId, untilMs, reason);
+    running.bus.emit({
+      type: 'status', from: role, reason: 'task-blocked',
+      msg: `task ${taskId} blocked until ${new Date(untilMs).toISOString()}${reason ? `: ${reason}` : ''}`,
+      data: { taskId, blockedUntil: untilMs, reason },
+    });
+    return JSON.stringify({ blocked: taskId, until: new Date(untilMs).toISOString(), status: task.status });
+  } catch (err) {
+    return JSON.stringify({ error: (err as Error).message });
+  }
+}
+
 export function dagCompleteTask(daemon: OrgDaemon, org: string, role: string, taskId: string, result?: string): string {
   const running = daemon.orgs.get(org);
   if (!running?.taskDag) return JSON.stringify({ error: 'org not running' });

--- a/packages/@monomind/cli/src/orgrt/session.ts
+++ b/packages/@monomind/cli/src/orgrt/session.ts
@@ -164,6 +164,11 @@ export interface SessionOpts {
   splitTask?: (role: string, parentId: string, children: { title: string; assignee: string }[]) => string;
   mergeTask?: (role: string, sourceId: string, targetId: string) => string;
   cancelTask?: (role: string, taskId: string, reason?: string) => string;
+  /** Task DAG: mark a 'running' task as waiting on a real-world time (not a
+   *  dependency) — e.g. a scheduled soak test, a CI run, a human-set
+   *  deadline. The idle watchdog skips nudging while any task is actively
+   *  blocked, and auto-resumes (re-dispatches) it once the time passes. */
+  blockTask?: (role: string, taskId: string, untilIso: string, reason?: string) => string;
   planGraph?: (role: string, specs: { name: string; title: string; assignee: string; after?: string[] }[]) => string;
 }
 
@@ -181,7 +186,7 @@ export function buildRolePrompt(role: OrgRole, def: Pick<OrgDef, 'name' | 'goal'
     `If you need a human decision, call ask_human with your question, then end your turn - you'll receive the human's answer as a new message when it arrives. Do not call ask_human for anything you can resolve yourself.`,
     `For irreversible or high-risk actions (deployments, deletions, external communications), call org_gate to create a decision gate — a hard-blocking approval checkpoint. End your turn and wait for the human's approval or rejection before proceeding.`,
     `You can structure work as a task DAG: use org_task to create tasks with dependencies, org_task_done to mark them complete, and org_tasks to see the full DAG. Tasks with satisfied dependencies are automatically dispatched to their assignee.`,
-    `The work graph is dynamic: call org_task_split when scope expands, org_task_merge when parallel branches converge early, or org_task_cancel when evidence makes a planned task moot. Use org_plan_graph to propose a full work graph in one call when you know the plan upfront.`,
+    `The work graph is dynamic: call org_task_split when scope expands, org_task_merge when parallel branches converge early, or org_task_cancel when evidence makes a planned task moot. Use org_plan_graph to propose a full work graph in one call when you know the plan upfront. If a task genuinely can't proceed until a specific real-world time — a scheduled long-running process, a deadline someone gave you, anything with a known future unblock time — call org_task_block instead of leaving it idle: it stops the idle watchdog from nudging you about it and automatically resumes the task when the time arrives, instead of you repeatedly re-confirming "still waiting" every idle cycle.`,
     `Before starting substantial work, call org_recall to check what previous runs already learned or delivered - do not redo finished work.`,
     `The user's documents (notes, handbooks, specs) are searchable with knowledge_search - ground your work in them instead of guessing; results labeled [global] come from the user's personal cross-project brain.`,
     `When you receive a message, act on it, then org_send your result to the requester.`,
@@ -622,6 +627,14 @@ export function buildOrgTools(opts: SessionOpts): OrgToolDef[] {
       description: 'Cancel a task as moot. The task becomes "cancelled" and unblocks downstream work.',
       schema: { taskId: z.string(), reason: z.string().optional() },
       handler: async (args) => text(opts.cancelTask!(role.id, args.taskId as string, args.reason as string | undefined)),
+    });
+  }
+  if (opts.blockTask) {
+    tools.push({
+      name: 'org_task_block',
+      description: 'Mark a task you are actively working (status "running") as blocked on a real-world time, not on other tasks — e.g. a scheduled soak test, a CI run that takes hours, a human-set deadline. Use this INSTEAD of leaving the task "running" with nothing actually happening, and instead of calling org_complete just because there is genuinely nothing to do right now: the idle watchdog will stop nudging you about this task until the time you give arrives, then automatically re-dispatch it to you. Give untilIso as an ISO 8601 date/time (e.g. "2026-08-19T09:00:00Z").',
+      schema: { taskId: z.string(), untilIso: z.string(), reason: z.string().optional() },
+      handler: async (args) => text(opts.blockTask!(role.id, args.taskId as string, args.untilIso as string, args.reason as string | undefined)),
     });
   }
   if (opts.planGraph) {

--- a/packages/@monomind/cli/src/orgrt/task-dag.ts
+++ b/packages/@monomind/cli/src/orgrt/task-dag.ts
@@ -1,6 +1,6 @@
 // packages/@monomind/cli/src/orgrt/task-dag.ts
 
-export type OrgTaskStatus = 'pending' | 'ready' | 'running' | 'done' | 'failed' | 'split' | 'merged' | 'cancelled';
+export type OrgTaskStatus = 'pending' | 'ready' | 'running' | 'blocked' | 'done' | 'failed' | 'split' | 'merged' | 'cancelled';
 
 export interface OrgTask {
   id: string;
@@ -14,6 +14,15 @@ export interface OrgTask {
   completedAt?: number;
   splitFrom?: string;
   mergedInto?: string;
+  /** Set when status is 'blocked': the task can't proceed until this real-world
+   *  time (e.g. waiting on a scheduled external process — a CI run, a soak
+   *  test, a human-set deadline). Distinct from a dependency block (deps not
+   *  yet done): this is an explicit "nothing to do until <time>" signal a role
+   *  gives when genuinely no other task is dispatchable. The idle watchdog
+   *  treats an active block the same as a pending decision gate — legitimate
+   *  waiting, not silence to nudge about. */
+  blockedUntil?: number;
+  blockedReason?: string;
 }
 
 export interface SplitChild {
@@ -68,6 +77,46 @@ export class TaskDag {
       t.status = 'running';
       t.startedAt = Date.now();
     }
+  }
+
+  /** Mark a task as waiting on a real-world time, not on other tasks. Only
+   *  valid from 'running' (a role already working it discovers it can't
+   *  proceed further right now) — a 'ready'/'pending' task should just stay
+   *  that way until its deps clear. */
+  block(id: string, untilMs: number, reason?: string): OrgTask {
+    const t = this.tasks.get(id);
+    if (!t) throw new Error(`task "${id}" not found`);
+    if (t.status !== 'running') throw new Error(`task "${id}" must be 'running' to block (is '${t.status}')`);
+    if (untilMs <= Date.now()) throw new Error(`blockedUntil must be in the future`);
+    t.status = 'blocked';
+    t.blockedUntil = untilMs;
+    t.blockedReason = reason;
+    return t;
+  }
+
+  /** Transition every task whose block has expired back to 'running', so its
+   *  assignee gets nudged that it's time to resume. Called by the idle
+   *  watchdog on every tick — cheap no-op when nothing has expired. */
+  unblockExpired(now: number): OrgTask[] {
+    const unblocked: OrgTask[] = [];
+    for (const t of this.tasks.values()) {
+      if (t.status === 'blocked' && (t.blockedUntil ?? Infinity) <= now) {
+        t.status = 'running';
+        t.blockedUntil = undefined;
+        t.blockedReason = undefined;
+        unblocked.push(t);
+      }
+    }
+    return unblocked;
+  }
+
+  /** True if any task is blocked on a real-world time still in the future —
+   *  the watchdog's signal to skip nudging (same treatment as a pending gate). */
+  hasActiveBlock(now: number): boolean {
+    for (const t of this.tasks.values()) {
+      if (t.status === 'blocked' && (t.blockedUntil ?? 0) > now) return true;
+    }
+    return false;
   }
 
   split(parentId: string, children: SplitChild[]): OrgTask[] {


### PR DESCRIPTION
Fixes #175.

## Summary
- No task status represented "waiting on a real-world time" — only dependency-based blocking existed. A role genuinely waiting on a scheduled external process (soak test, CI run, deadline) had to leave its task `'running'` forever, giving the idle watchdog no way to distinguish legitimate bounded waiting from a genuine stall.
- Observed live: a role's own chat literally said "task-4 status='running' represents standby/blocked state (no 'blocked' status in org task model)" — confirming the gap directly, in the org's own words. The watchdog then nudged every ~10-20 minutes for hours, each nudge a real LLM turn producing nothing but a trivial "still waiting" reply.

## What's added
- `OrgTask.blockedUntil` / `blockedReason` fields, new `'blocked'` status (`task-dag.ts`). `TaskDag.block()` / `unblockExpired()` / `hasActiveBlock()`. `'blocked'` is deliberately NOT in the `SATISFIED` set, so downstream dependents correctly stay `'pending'` rather than treating a block as done.
- `org_task_block` tool (`session.ts`): a role working a `'running'` task can mark it blocked until an ISO timestamp with a reason.
- Idle watchdog (`daemon.ts`): every tick, auto-resumes (re-dispatches into the assignee's mailbox) any task whose block has expired — counts as real activity, resets the idle clock. While any task is actively blocked into the future, the watchdog skips nudging entirely — same treatment as an already-pending decision gate.
- Kickoff briefing text points the boss at `org_task_block` as the correct move instead of leaving a task idle or ending the run early.

## Test plan
- [x] `task-dag-block.test.ts` (10 tests): block requires `'running'` status and a future timestamp, `hasActiveBlock`/`unblockExpired` transition correctly at the boundary, downstream deps stay `pending` while blocked (not falsely satisfied).
- [x] `dag-block-task.test.ts` (4 tests): the daemon-facing `dagBlockTask` wiring — bus event emission, error JSON (not a throw) on bad input, the shared "org not running" guard.
- [x] Verified all 14 new tests fail against the pre-fix code (`git stash` the source changes, rerun) and pass with the fix.
- [x] `tsc --noEmit` clean.
- [x] `biome check`: diffed diagnostics per-file against the pre-fix baseline — every flagged location is byte-identical (same rule, just a shifted line number from the new code above it). Zero new lint issues.
- [x] Ran alongside `org-approval-gate.test.ts`, `idle-watchdog-nudge-reset.test.ts`, `org-complete-scope-guidance.test.ts` — all 50 tests across the 5 files pass together, no regressions.

🤖 Generated with [monomind](https://github.com/monoes/monomind)