### PR TITLE
fix(tests): de-flake orgrt server auth port race and replay cleanup

### DIFF
--- a/packages/@monomind/cli/__tests__/orgrt/org-observe-replay.test.ts
+++ b/packages/@monomind/cli/__tests__/orgrt/org-observe-replay.test.ts
@@ -65,8 +65,17 @@ describe('org replay CLI action — honors the requested run id (#114)', () => {
       expect(result.success).toBe(true);
       expect(result.message).toContain(firstRun);
     } finally {
+      // replayAction leaves the org running by design (it prints "Stop with:
+      // monomind org stop ..."), with its own internal OrgDaemon still
+      // writing bus.jsonl/checkpoints under root. A bare rmSync can race
+      // that write and throw ENOTEMPTY; retry and don't let leftover temp
+      // files fail the test.
       const { rmSync } = await import('node:fs');
-      rmSync(root, { recursive: true, force: true });
+      try {
+        rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+      } catch {
+        /* best effort — see comment above */
+      }
     }
   }, 20_000);
 
@@ -86,8 +95,15 @@ describe('org replay CLI action — honors the requested run id (#114)', () => {
       expect(result.success).toBe(false);
       expect(result.message).toContain('not found');
     } finally {
+      // See comment in the previous test's finally block — the first
+      // startOrg/stopOrg cycle here also leaves internal daemon state that
+      // can race a bare rmSync.
       const { rmSync } = await import('node:fs');
-      rmSync(root, { recursive: true, force: true });
+      try {
+        rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+      } catch {
+        /* best effort */
+      }
     }
   }, 20_000);
 });

--- a/tests/security/orgrt-server-auth.test.ts
+++ b/tests/security/orgrt-server-auth.test.ts
@@ -15,6 +15,13 @@
  * cred → 200. The timing assertion is intentionally weak (we don't claim
  * a measurable constant-time guarantee in JS, only that the primitive in
  * use is `timingSafeEqual`); the regression value is in the auth logic.
+ *
+ * Port allocation: `startOrgServer` already accepts `port = 0` and returns
+ * the kernel-assigned port on `OrgServer.port`. We used to pre-allocate a
+ * port via a throwaway `http.Server`, close it, and pass the number back in
+ * — a TOCTOU race under parallel test workers (another file can grab the
+ * port in the gap, surfacing as `EADDRINUSE`). Letting `startOrgServer` bind
+ * `:0` itself is atomic and removes the race entirely.
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import http from 'node:http';
@@ -24,18 +31,6 @@ interface Spawned {
   close: () => void;
 }
 const spawned: Spawned[] = [];
-
-async function freePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const s = http.createServer();
-    s.unref();
-    s.on('error', reject);
-    s.listen(0, '127.0.0.1', () => {
-      const p = (s.address() as { port: number }).port;
-      s.close(() => resolve(p));
-    });
-  });
-}
 
 // The server only invokes daemon methods on the success path beyond the auth
 // gate. For auth tests we never reach them (401 short-circuits), and for the
@@ -75,18 +70,16 @@ function req(
 
 describe('SEC-2 — org server timing-safe auth', () => {
   it('rejects requests with no credential (GET /api/status)', async () => {
-    const port = await freePort();
-    const srv = await startOrgServer(stubDaemon(), port, 'sekret');
+    const srv = await startOrgServer(stubDaemon(), 0, 'sekret');
     spawned.push(srv);
-    const r = await req(port);
+    const r = await req(srv.port);
     expect(r.status).toBe(401);
   });
 
   it('rejects requests with the wrong credential', async () => {
-    const port = await freePort();
-    const srv = await startOrgServer(stubDaemon(), port, 'sekret');
+    const srv = await startOrgServer(stubDaemon(), 0, 'sekret');
     spawned.push(srv);
-    const r = await req(port, { 'x-monomind-cred': 'wrong' });
+    const r = await req(srv.port, { 'x-monomind-cred': 'wrong' });
     expect(r.status).toBe(401);
   });
 
@@ -94,29 +87,26 @@ describe('SEC-2 — org server timing-safe auth', () => {
     // The classic timing-attack target: a secret 'sekret' and a guess
     // 'sekreu' (last byte differs). Pre-fix, `!==` short-circuited late;
     // post-fix, length matches so timingSafeEqual runs the full compare.
-    const port = await freePort();
-    const srv = await startOrgServer(stubDaemon(), port, 'sekret');
+    const srv = await startOrgServer(stubDaemon(), 0, 'sekret');
     spawned.push(srv);
-    const r = await req(port, { 'x-monomind-cred': 'sekreu' });
+    const r = await req(srv.port, { 'x-monomind-cred': 'sekreu' });
     expect(r.status).toBe(401);
   });
 
   it('accepts requests with the correct credential', async () => {
-    const port = await freePort();
-    const srv = await startOrgServer(stubDaemon(), port, 'sekret');
+    const srv = await startOrgServer(stubDaemon(), 0, 'sekret');
     spawned.push(srv);
-    const r = await req(port, { 'x-monomind-cred': 'sekret' });
+    const r = await req(srv.port, { 'x-monomind-cred': 'sekret' });
     expect(r.status).toBe(200);
   });
 
   it('POST endpoints also reject missing cred', async () => {
-    const port = await freePort();
-    const srv = await startOrgServer(stubDaemon(), port, 'sekret');
+    const srv = await startOrgServer(stubDaemon(), 0, 'sekret');
     spawned.push(srv);
     const r = await new Promise<{ status: number }>((resolve, reject) => {
       const r2 = http.request(
         {
-          port,
+          port: srv.port,
           host: '127.0.0.1',
           path: '/api/xdeliver',
           method: 'POST',
@@ -133,44 +123,50 @@ describe('SEC-2 — org server timing-safe auth', () => {
     expect(r.status).toBe(401);
   });
 
-  it('credential comparison runs in roughly constant time across mismatched bytes', async () => {
-    // Statistical sanity check — NOT a rigorous constant-time proof (JS GC /
-    // event-loop jitter makes that impossible). We measure two populations:
-    // (A) credentials that share NO bytes with the secret,
-    // (B) credentials that share ALL bytes except the last.
-    // Pre-fix, B was measurably slower than A. Post-fix, with
-    // timingSafeEqual, the two distributions overlap.
-    const port = await freePort();
-    const secret = 'a'.repeat(32);
-    const srv = await startOrgServer(stubDaemon(), port, secret);
-    spawned.push(srv);
+  it(
+    'credential comparison runs in roughly constant time across mismatched bytes',
+    async () => {
+      // Statistical sanity check — NOT a rigorous constant-time proof (JS GC /
+      // event-loop jitter makes that impossible). We measure two populations:
+      // (A) credentials that share NO bytes with the secret,
+      // (B) credentials that share ALL bytes except the last.
+      // Pre-fix, B was measurably slower than A. Post-fix, with
+      // timingSafeEqual, the two distributions overlap.
+      const secret = 'a'.repeat(32);
+      const srv = await startOrgServer(stubDaemon(), 0, secret);
+      spawned.push(srv);
 
-    const N = 200;
-    const noMatch: number[] = [];
-    const lastByteDiff: number[] = [];
-    // Warm up to avoid first-call JIT skewing.
-    for (let i = 0; i < 20; i++) await req(port, { 'x-monomind-cred': 'x'.repeat(32) });
+      // Trimmed from 200 to 60 (120 paired samples total) — plenty to catch a
+      // ~1.5x+ regression while keeping the ~420-request version's CI-timeout
+      // risk off the table.
+      const N = 60;
+      const noMatch: number[] = [];
+      const lastByteDiff: number[] = [];
+      // Warm up to avoid first-call JIT skewing.
+      for (let i = 0; i < 20; i++) await req(srv.port, { 'x-monomind-cred': 'x'.repeat(32) });
 
-    for (let i = 0; i < N; i++) {
-      const tA = performance.now();
-      await req(port, { 'x-monomind-cred': 'x'.repeat(32) });
-      noMatch.push(performance.now() - tA);
+      for (let i = 0; i < N; i++) {
+        const tA = performance.now();
+        await req(srv.port, { 'x-monomind-cred': 'x'.repeat(32) });
+        noMatch.push(performance.now() - tA);
 
-      const guess = 'a'.repeat(31) + 'b';
-      const tB = performance.now();
-      await req(port, { 'x-monomind-cred': guess });
-      lastByteDiff.push(performance.now() - tB);
-    }
+        const guess = 'a'.repeat(31) + 'b';
+        const tB = performance.now();
+        await req(srv.port, { 'x-monomind-cred': guess });
+        lastByteDiff.push(performance.now() - tB);
+      }
 
-    const mean = (xs: number[]) => xs.reduce((s, x) => s + x, 0) / xs.length;
-    const mA = mean(noMatch);
-    const mB = mean(lastByteDiff);
-    // Pre-fix, mB/mA could exceed 1.5+ (string !== short-circuit). Post-fix,
-    // both paths go through the same Buffer+timingSafeEqual so the ratio is
-    // close to 1. Allow a wide band (3x) to absorb GC/network jitter — the
-    // goal is to detect the OLD behaviour, not to prove nanosecond equality.
-    expect(Number.isFinite(mA)).toBe(true);
-    expect(Number.isFinite(mB)).toBe(true);
-    expect(mB / mA).toBeLessThan(3);
-  });
+      const mean = (xs: number[]) => xs.reduce((s, x) => s + x, 0) / xs.length;
+      const mA = mean(noMatch);
+      const mB = mean(lastByteDiff);
+      // Pre-fix, mB/mA could exceed 1.5+ (string !== short-circuit). Post-fix,
+      // both paths go through the same Buffer+timingSafeEqual so the ratio is
+      // close to 1. Allow a wide band (3x) to absorb GC/network jitter — the
+      // goal is to detect the OLD behaviour, not to prove nanosecond equality.
+      expect(Number.isFinite(mA)).toBe(true);
+      expect(Number.isFinite(mB)).toBe(true);
+      expect(mB / mA).toBeLessThan(3);
+    },
+    60_000,
+  );
 });


### PR DESCRIPTION
## Summary
- Removes a TOCTOU port-race in `tests/security/orgrt-server-auth.test.ts` (`freePort()` pre-allocated a port, closed the socket, then re-bound it later — under parallel CI workers another file could grab it in the gap, surfacing as `EADDRINUSE`). `startOrgServer` already returns the real bound port on `OrgServer.port` when called with `port: 0`, so tests now use that directly.
- Trims the timing-safe-compare sanity test from 420 sequential HTTP round trips (200 samples) to 120 (60 samples) and gives it an explicit 60s timeout, so it can't trip vitest's 30s default under CI load. Assertion (`mB/mA < 3`) is unchanged.
- Fixes `packages/@monomind/cli/__tests__/orgrt/org-observe-replay.test.ts`: `replayAction` intentionally leaves the replayed org running (its own `OrgDaemon` keeps writing checkpoints), so the test's bare `rmSync` in `finally` could race that write and throw `ENOTEMPTY`. Now retries with `maxRetries`/`retryDelay` and swallows leftover-tmpdir failures.

Both are pre-existing flakes on `main` that were blocking CI on #176 and #184 — confirmed via `gh pr diff --name-only` that neither PR's own diff touches either test file.

## Test plan
- [x] `npx vitest run tests/security/orgrt-server-auth.test.ts` — 6/6, ran 3x back-to-back, ~40-70ms each (was 30s+ timeout before)
- [x] `npx vitest run tests/security/` — 15 files / 138 tests green
- [x] `npx vitest run __tests__/orgrt/org-observe-replay.test.ts` (cli package) — 2/2 green
- [x] `npm run build` — clean (after building sibling workspace packages, a pre-existing local sequencing requirement unrelated to this change)
- [x] Confirmed on `origin/main` (via `git stash`) that this build error and the two unrelated flaky tests (`daemon.test.ts`, `server.test.ts` in the cli orgrt suite) pre-exist without this diff

🤖 Generated with [monomind](https://github.com/monoes/monomind)