### PR TITLE
feat(orgrt): resolve #177 — wire UsageProxyServer through to CrushAgentRunner

### DIFF
--- a/packages/@monomind/cli/__tests__/orgrt/resolve-runner-usage-proxy.test.ts
+++ b/packages/@monomind/cli/__tests__/orgrt/resolve-runner-usage-proxy.test.ts
@@ -1,0 +1,96 @@
+// packages/@monomind/cli/__tests__/orgrt/resolve-runner-usage-proxy.test.ts
+//
+// Regression test for #177: UsageProxyServer was fully built and
+// CrushAgentRunner already accepted a `usageProxy` constructor option, but
+// nothing in resolveRunner/resolveRoleRunner ever threaded a role's config
+// through to it — the feature was dead code. Fixed by adding
+// `provider.usageProxy` / `provider.usageProxyEnvVar` to ProviderSchema and
+// forwarding them from resolveRoleRunner -> resolveRunner -> CrushAgentRunner.
+import { describe, it, expect, vi } from 'vitest';
+
+const crushCtor = vi.fn();
+vi.mock('../../src/orgrt/crush-runner.js', () => ({
+  CrushAgentRunner: class {
+    constructor(opts: unknown) {
+      crushCtor(opts);
+    }
+  },
+}));
+
+import { resolveRunner, resolveRoleRunner } from '../../src/orgrt/daemon.js';
+import type { ProviderConfig } from '../../src/orgrt/types.js';
+
+describe('resolveRunner — crush usage-proxy wiring (#177)', () => {
+  it('constructs CrushAgentRunner with no usageProxy option when provider is absent', () => {
+    crushCtor.mockClear();
+    resolveRunner('crush');
+    expect(crushCtor).toHaveBeenCalledWith(undefined);
+  });
+
+  it('constructs CrushAgentRunner with no usageProxy option when provider.usageProxy is not set', () => {
+    crushCtor.mockClear();
+    const provider = { kind: 'subscription', baseUrl: 'https://api.example.com/v1' } as ProviderConfig;
+    resolveRunner('crush', undefined, provider);
+    expect(crushCtor).toHaveBeenCalledWith(undefined);
+  });
+
+  it('constructs CrushAgentRunner with no usageProxy option when usageProxy is true but baseUrl is missing', () => {
+    crushCtor.mockClear();
+    const provider = { kind: 'subscription', usageProxy: true } as ProviderConfig;
+    resolveRunner('crush', undefined, provider);
+    expect(crushCtor).toHaveBeenCalledWith(undefined);
+  });
+
+  it('threads provider.baseUrl into CrushAgentRunner.usageProxy.upstreamBaseUrl when usageProxy=true', () => {
+    crushCtor.mockClear();
+    const provider = {
+      kind: 'subscription',
+      usageProxy: true,
+      baseUrl: 'https://api.example.com/v1',
+    } as ProviderConfig;
+    resolveRunner('crush', undefined, provider);
+    expect(crushCtor).toHaveBeenCalledWith({
+      usageProxy: { upstreamBaseUrl: 'https://api.example.com/v1', baseUrlEnvVar: undefined },
+    });
+  });
+
+  it('threads a custom usageProxyEnvVar through as baseUrlEnvVar', () => {
+    crushCtor.mockClear();
+    const provider = {
+      kind: 'subscription',
+      usageProxy: true,
+      baseUrl: 'https://api.example.com/v1',
+      usageProxyEnvVar: 'CRUSH_BASE_URL',
+    } as ProviderConfig;
+    resolveRunner('crush', undefined, provider);
+    expect(crushCtor).toHaveBeenCalledWith({
+      usageProxy: { upstreamBaseUrl: 'https://api.example.com/v1', baseUrlEnvVar: 'CRUSH_BASE_URL' },
+    });
+  });
+
+  it('resolveRoleRunner forwards the role provider through to resolveRunner for an explicit role runtime', () => {
+    crushCtor.mockClear();
+    const roleProvider = {
+      kind: 'subscription',
+      usageProxy: true,
+      baseUrl: 'https://role.example.com/v1',
+    } as ProviderConfig;
+    resolveRoleRunner('crush', undefined, undefined, undefined, roleProvider);
+    expect(crushCtor).toHaveBeenCalledWith({
+      usageProxy: { upstreamBaseUrl: 'https://role.example.com/v1', baseUrlEnvVar: undefined },
+    });
+  });
+
+  it('resolveRoleRunner forwards the role provider through to resolveRunner when runtime is inherited from org', () => {
+    crushCtor.mockClear();
+    const roleProvider = {
+      kind: 'subscription',
+      usageProxy: true,
+      baseUrl: 'https://org-inherited.example.com/v1',
+    } as ProviderConfig;
+    resolveRoleRunner(undefined, 'crush', undefined, undefined, roleProvider);
+    expect(crushCtor).toHaveBeenCalledWith({
+      usageProxy: { upstreamBaseUrl: 'https://org-inherited.example.com/v1', baseUrlEnvVar: undefined },
+    });
+  });
+});

--- a/packages/@monomind/cli/src/orgrt/daemon.ts
+++ b/packages/@monomind/cli/src/orgrt/daemon.ts
@@ -18,6 +18,7 @@ import {
   type OrgRole,
   type BusEvent,
   type DecisionGate,
+  type ProviderConfig,
   ORG_DIR,
 } from './types.js';
 import { TaskDag } from './task-dag.js';
@@ -147,6 +148,7 @@ function autoRuntimeFromProvider(kind?: ProviderKind): RuntimeKind | undefined {
 export function resolveRunner(
   orgRuntime?: RuntimeKind,
   providerKind?: ProviderKind,
+  provider?: ProviderConfig,
 ): AgentRunner | undefined {
   const selected =
     orgRuntime ??
@@ -159,7 +161,18 @@ export function resolveRunner(
   if (selected === 'antigravity') return new AntigravityAgentRunner();
   if (selected === 'grok') return new GrokAgentRunner();
   if (selected === 'qwen') return new QwenAgentRunner();
-  if (selected === 'crush') return new CrushAgentRunner();
+  if (selected === 'crush') {
+    // Issue #177: usage-proxy accounting is opt-in via provider.usageProxy +
+    // provider.baseUrl (the upstream the crush CLI's own provider config
+    // points at). Absent either, CrushAgentRunner falls back to its
+    // documented 0-token behavior — this never blocks a turn either way.
+    if (provider?.usageProxy && provider.baseUrl) {
+      return new CrushAgentRunner({
+        usageProxy: { upstreamBaseUrl: provider.baseUrl, baseUrlEnvVar: provider.usageProxyEnvVar },
+      });
+    }
+    return new CrushAgentRunner();
+  }
   if (selected === 'copilot') return new CopilotAgentRunner();
   if (selected === 'pi') return new PiAgentRunner();
   if (selected === 'pi-rpc') return new PiRpcAgentRunner();
@@ -176,10 +189,11 @@ export function resolveRoleRunner(
   orgRuntime?: RuntimeKind,
   roleProviderKind?: ProviderKind,
   orgProviderKind?: ProviderKind,
+  roleProvider?: ProviderConfig,
 ): AgentRunner | undefined {
   const explicit = roleRuntime ?? orgRuntime;
-  if (explicit) return resolveRunner(explicit);
-  return resolveRunner(undefined, roleProviderKind ?? orgProviderKind);
+  if (explicit) return resolveRunner(explicit, undefined, roleProvider);
+  return resolveRunner(undefined, roleProviderKind ?? orgProviderKind, roleProvider);
 }
 
 /** Per-role token budget: a role's own `budget_tokens` wins; otherwise the
@@ -919,7 +933,7 @@ export class OrgDaemon {
         // built per role here in spawnRole, so each role gets its own runner.
         runner:
           this.opts.runner ??
-          resolveRoleRunner(role.runtime, def.runtime, role.provider?.kind, undefined),
+          resolveRoleRunner(role.runtime, def.runtime, role.provider?.kind, undefined, role.provider),
       };
       // Supervised session: transient crashes (provider blips, network) restart
       // with backoff; a crash with the mailbox already closed, or one that

--- a/packages/@monomind/cli/src/orgrt/types.ts
+++ b/packages/@monomind/cli/src/orgrt/types.ts
@@ -44,6 +44,16 @@ export const ProviderSchema = z.object({
   baseUrl: z.string().optional(),
   /** env var NAME holding the auth token for base-url providers */
   authTokenEnv: z.string().optional(),
+  /** Opt in to UsageProxyServer token accounting for runtimes whose CLI output
+   *  doesn't self-report usage (currently just `runtime: 'crush'`). When true,
+   *  `baseUrl` above is treated as the upstream the CLI's own provider config
+   *  points at, and the runner routes its traffic through a local proxy that
+   *  parses usage out of the relayed request/response bodies. No effect for
+   *  runtimes that don't support it (usage-proxy.ts, crush-runner.ts). */
+  usageProxy: z.boolean().optional(),
+  /** Override the env var the proxied CLI reads for its base-URL override.
+   *  Defaults to CrushAgentRunner's own guess (OPENAI_BASE_URL) when unset. */
+  usageProxyEnvVar: z.string().optional(),
 }).strict();
 
 const THREAT_TYPES = ['prompt_injection', 'jailbreak', 'pii_exposure', 'instruction_override',


### PR DESCRIPTION
## Summary
Closes #177.

- `ProviderSchema` gains two optional fields: `usageProxy` (opt-in bool) and `usageProxyEnvVar` (override for the CLI's base-URL env var). The existing `baseUrl` field is reused as the upstream the proxy relays to — no new duplicate field.
- `resolveRunner`/`resolveRoleRunner` gain an optional `ProviderConfig` param, forwarded from `daemon.ts`'s `spawnRole` call site (`role.provider`), and construct `CrushAgentRunner` with `{ usageProxy: { upstreamBaseUrl, baseUrlEnvVar } }` only when `usageProxy: true` **and** `baseUrl` is set. Absent either, behavior is byte-for-byte unchanged (`new CrushAgentRunner()`, same as today).
- New test file `resolve-runner-usage-proxy.test.ts` covers all four gating combinations (absent provider, no `usageProxy`, `usageProxy` without `baseUrl`, both set) plus the custom-env-var override, for both `resolveRunner` and `resolveRoleRunner`, via a mocked `CrushAgentRunner` constructor.

`CopilotAgentRunner` intentionally not touched — GitHub's backend isn't proxyable the same way (per #177's own note).

## Test plan
- [x] `npx vitest run __tests__/orgrt/resolve-runner-usage-proxy.test.ts` — 7/7 green
- [x] `npx vitest run __tests__/orgrt/` (full cli orgrt suite) — 451/452 passed, 1 skipped, zero regressions
- [x] `npm run build` — clean

🤖 Generated with [monomind](https://github.com/monoes/monomind)