### PR TITLE
fix(orgrt): resolve #179 — use pi's agent_end event instead of get_state polling

### DIFF
--- a/packages/@monomind/cli/__tests__/orgrt/pi-rpc-runner.test.ts
+++ b/packages/@monomind/cli/__tests__/orgrt/pi-rpc-runner.test.ts
@@ -111,7 +111,7 @@ async function collect(iter: AsyncIterable<AgentMessage>): Promise<AgentMessage[
 }
 
 describe('PiRpcAgentRunner — turn-completion state machine', () => {
-  it('sends one prompt command and yields assistant text once isStreaming settles to false', async () => {
+  it('sends one prompt command and yields assistant text once agent_end arrives', async () => {
     const proc = fakeProcess();
     const runner = new PiRpcAgentRunner('pi', () => proc);
 
@@ -122,12 +122,18 @@ describe('PiRpcAgentRunner — turn-completion state machine', () => {
     expect(proc.written[0]).toContain('"type":"prompt"');
 
     proc.emitStdout('{"type":"agent_start"}\n');
-    proc.emitStdout('{"type":"message_end","message":{"content":[{"type":"text","text":"Hi there"}]}}\n');
-    await new Promise((r) => setTimeout(r, 10));
-    // The runner should have asked get_state after message_end.
-    expect(proc.written.some((w) => w.includes('"type":"get_state"'))).toBe(true);
-
-    proc.emitStdout('{"type":"response","command":"get_state","success":true,"data":{"isStreaming":false}}\n');
+    // Intermediate turn_start/turn_end/message_* events are drained and
+    // ignored — only agent_end carries the signal this runner acts on.
+    proc.emitStdout('{"type":"turn_start"}\n');
+    proc.emitStdout('{"type":"message_end","message":{"content":[{"type":"text","text":"ignored — not agent_end"}]}}\n');
+    proc.emitStdout('{"type":"turn_end"}\n');
+    proc.emitStdout(JSON.stringify({
+      type: 'agent_end',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'Hi there' }], usage: { input: 10, output: 5 } },
+      ],
+    }) + '\n');
     proc.emitClose(0);
 
     const messages = await resultsPromise;
@@ -135,32 +141,39 @@ describe('PiRpcAgentRunner — turn-completion state machine', () => {
     expect(assistant.map((m) => m.text)).toEqual(['Hi there']);
     const result = messages.find((m) => m.type === 'result');
     expect(result).toBeDefined();
+    expect(result?.input_tokens).toBe(10);
+    expect(result?.output_tokens).toBe(5);
   });
 
-  it('keeps waiting through multiple message_end cycles while pi is still streaming', async () => {
+  it('consolidates text and sums usage across multiple internal turns in one agent_end (pi\'s own native tool use)', async () => {
     const proc = fakeProcess();
     const runner = new PiRpcAgentRunner('pi', () => proc);
     const resultsPromise = collect(runner.run(baseArgs(singlePrompt('hello'))));
     await new Promise((r) => setTimeout(r, 10));
 
-    // First internal cycle: pi is still working (its own native tool use).
-    proc.emitStdout('{"type":"message_end","message":{"content":[{"type":"text","text":"working on it"}]}}\n');
-    await new Promise((r) => setTimeout(r, 10));
-    proc.emitStdout('{"type":"response","command":"get_state","success":true,"data":{"isStreaming":true}}\n');
-    await new Promise((r) => setTimeout(r, 10));
-
-    // Second cycle: now it's actually done.
-    proc.emitStdout('{"type":"message_end","message":{"content":[{"type":"text","text":"done now"}]}}\n');
-    await new Promise((r) => setTimeout(r, 10));
-    proc.emitStdout('{"type":"response","command":"get_state","success":true,"data":{"isStreaming":false}}\n');
+    // agent_end.messages carries one assistant entry per internal turn,
+    // each with its OWN per-turn usage — confirmed live against pi v0.73.1
+    // (see file header). The runner must sum across all of them, not just
+    // read the last one.
+    proc.emitStdout(JSON.stringify({
+      type: 'agent_end',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+        { role: 'assistant', content: [{ type: 'thinking', thinking: '...' }, { type: 'toolCall', id: 'c1', name: 'bash', arguments: {} }], usage: { input: 10, output: 20 } },
+        { role: 'toolResult', content: [{ type: 'text', text: 'tool output' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'done now' }], usage: { input: 15, output: 8 } },
+      ],
+    }) + '\n');
     proc.emitClose(0);
 
     const messages = await resultsPromise;
-    // Text from both internal cycles is consolidated into one assistant
-    // message once the turn actually settles (isStreaming:false) — not one
-    // yield per message_end, since intermediate cycles aren't "done" yet.
     const assistant = messages.filter((m) => m.type === 'assistant').map((m) => m.text);
-    expect(assistant).toEqual(['working on it\ndone now']);
+    // Only text blocks from assistant entries are surfaced — toolResult and
+    // toolCall entries are not text the org bus should see.
+    expect(assistant).toEqual(['done now']);
+    const result = messages.find((m) => m.type === 'result');
+    expect(result?.input_tokens).toBe(25); // 10 + 15
+    expect(result?.output_tokens).toBe(28); // 20 + 8
   });
 
   it('extracts an org tool_call fence, executes it, and continues the same session', async () => {
@@ -180,9 +193,10 @@ describe('PiRpcAgentRunner — turn-completion state machine', () => {
     await new Promise((r) => setTimeout(r, 10));
 
     const fence = '```tool_call\n{"name":"org_send","arguments":{"to":"boss","subject":"s","message":"m"}}\n```';
-    proc.emitStdout(JSON.stringify({ type: 'message_end', message: { content: [{ type: 'text', text: `Sending now.\n${fence}` }] } }) + '\n');
-    await new Promise((r) => setTimeout(r, 10));
-    proc.emitStdout('{"type":"response","command":"get_state","success":true,"data":{"isStreaming":false}}\n');
+    proc.emitStdout(JSON.stringify({
+      type: 'agent_end',
+      messages: [{ role: 'assistant', content: [{ type: 'text', text: `Sending now.\n${fence}` }], usage: { input: 1, output: 1 } }],
+    }) + '\n');
     await new Promise((r) => setTimeout(r, 10));
 
     // The runner should have sent a follow-up prompt with the tool result —
@@ -191,9 +205,10 @@ describe('PiRpcAgentRunner — turn-completion state machine', () => {
     expect(secondPrompt).toBeDefined();
     expect(secondPrompt).not.toContain('You are a test agent'); // no system prompt re-sent
 
-    proc.emitStdout('{"type":"message_end","message":{"content":[{"type":"text","text":"Done."}]}}\n');
-    await new Promise((r) => setTimeout(r, 10));
-    proc.emitStdout('{"type":"response","command":"get_state","success":true,"data":{"isStreaming":false}}\n');
+    proc.emitStdout(JSON.stringify({
+      type: 'agent_end',
+      messages: [{ role: 'assistant', content: [{ type: 'text', text: 'Done.' }], usage: { input: 1, output: 1 } }],
+    }) + '\n');
     proc.emitClose(0);
 
     const messages = await resultsPromise;
@@ -210,9 +225,10 @@ describe('PiRpcAgentRunner — turn-completion state machine', () => {
 
     expect(proc.written[0]).toContain('You are a test agent');
 
-    proc.emitStdout('{"type":"message_end","message":{"content":[{"type":"text","text":"ok"}]}}\n');
-    await new Promise((r) => setTimeout(r, 10));
-    proc.emitStdout('{"type":"response","command":"get_state","success":true,"data":{"isStreaming":false}}\n');
+    proc.emitStdout(JSON.stringify({
+      type: 'agent_end',
+      messages: [{ role: 'assistant', content: [{ type: 'text', text: 'ok' }], usage: { input: 1, output: 1 } }],
+    }) + '\n');
     proc.emitClose(0);
     await resultsPromise;
   });
@@ -260,9 +276,10 @@ describe('PiRpcAgentRunner — turn-completion state machine', () => {
       await vi.advanceTimersByTimeAsync(10);
 
       const fence = '```tool_call\n{"name":"ask_human","arguments":{}}\n```';
-      proc.emitStdout(JSON.stringify({ type: 'message_end', message: { content: [{ type: 'text', text: `Asking.\n${fence}` }] } }) + '\n');
-      await vi.advanceTimersByTimeAsync(10);
-      proc.emitStdout('{"type":"response","command":"get_state","success":true,"data":{"isStreaming":false}}\n');
+      proc.emitStdout(JSON.stringify({
+        type: 'agent_end',
+        messages: [{ role: 'assistant', content: [{ type: 'text', text: `Asking.\n${fence}` }], usage: { input: 1, output: 1 } }],
+      }) + '\n');
       await vi.advanceTimersByTimeAsync(10);
 
       // The tool call is now blocked ("waiting on a human"). Advance well
@@ -273,9 +290,10 @@ describe('PiRpcAgentRunner — turn-completion state machine', () => {
       // Let the human "answer" and finish the turn normally.
       releaseTool();
       await vi.advanceTimersByTimeAsync(10);
-      proc.emitStdout(JSON.stringify({ type: 'message_end', message: { content: [{ type: 'text', text: 'Done.' }] } }) + '\n');
-      await vi.advanceTimersByTimeAsync(10);
-      proc.emitStdout('{"type":"response","command":"get_state","success":true,"data":{"isStreaming":false}}\n');
+      proc.emitStdout(JSON.stringify({
+        type: 'agent_end',
+        messages: [{ role: 'assistant', content: [{ type: 'text', text: 'Done.' }], usage: { input: 1, output: 1 } }],
+      }) + '\n');
       proc.emitClose(0);
       await vi.advanceTimersByTimeAsync(10);
 

--- a/packages/@monomind/cli/src/orgrt/pi-rpc-runner.ts
+++ b/packages/@monomind/cli/src/orgrt/pi-rpc-runner.ts
@@ -11,59 +11,67 @@
  * session, so conversational context carries naturally (no --session-dir
  * resume guessing) and there's no per-turn spawn/bootstrap cost.
  *
- * Protocol — JSON objects, one per line (LF-delimited), verified against
- * pi-mono's rpc.md doc source directly (literal JSON examples quoted below,
- * not paraphrased from prose — unlike this file's sibling runners, which
- * work from public docs that don't always show raw wire examples):
+ * Protocol — JSON objects, one per line (LF-delimited). RESOLVED against a
+ * live pi v0.73.1 install (issue #179): pi's docs (docs/rpc.md, bundled with
+ * the package) define `agent_end` — "Emitted when the agent completes.
+ * Contains all messages generated during this run." — as a distinct event
+ * from `message_end`/`turn_end`, and it's exactly the "prompt is fully done"
+ * signal this runner needs. Confirmed live with a prompt that made pi run 3
+ * of its own native tools in sequence (read → edit → bash): the run produced
+ * 4 separate turn_start/turn_end cycles and many message_end events, but
+ * EXACTLY ONE agent_end, firing only after the last turn closed. This
+ * replaces the old get_state-polling heuristic entirely — no more `isStreaming`
+ * ambiguity to worry about.
  *
  *   Client → server (this runner sends), each with an optional "id" for
  *   response correlation:
  *     {"type":"prompt","message":"<text>"}          — new/continuing turn
- *     {"type":"get_state"}                           — poll idle/streaming status
  *     {"type":"abort"}                                — not used by this runner
  *
- *   Server → client:
+ *   Server → client (only agent_end is acted on; everything else — agent_start,
+ *   turn_start/turn_end, message_start/message_update/message_end,
+ *   tool_execution_* — is drained and ignored):
  *     {"type":"response","command":"prompt","success":true}
- *     {"type":"response","command":"get_state","success":true,
- *      "data":{"isStreaming":false, ...}}
- *     {"type":"agent_start"}
- *     {"type":"message_update","usage":{"input":N,"output":N,"totalTokens":N,
- *      "cost":{"total":N}},"assistantMessageEvent":{...}}   — streaming deltas, ignored
- *     {"type":"message_end","message":{"role":"assistant","content":[
- *        {"type":"text","text":"..."},
- *        {"type":"thinking","thinking":"..."},
- *        {"type":"toolCall","id":"call_1","name":"bash","arguments":{...}}
- *      ]}}
+ *     {"type":"agent_end","messages":[
+ *        {"role":"user","content":[{"type":"text","text":"..."}]},
+ *        {"role":"assistant","content":[
+ *           {"type":"thinking","thinking":"..."},
+ *           {"type":"text","text":"..."},
+ *           {"type":"toolCall","id":"call_1","name":"bash","arguments":{...}}
+ *         ],"usage":{"input":N,"output":N,"totalTokens":N,"cost":{"total":N}}},
+ *        {"role":"toolResult","content":[{"type":"text","text":"..."}]},
+ *        ... (repeats per internal turn — one "assistant" entry per turn,
+ *             each with ITS OWN per-turn `usage`, not cumulative)
+ *      ]}
  *
- * KNOWN GAP — turn-completion detection is a best-effort HEURISTIC, not a
- * confirmed protocol contract: pi executes its own native tools (bash, file
- * edits, …) autonomously inside the RPC session, so a single `prompt` can
- * produce MULTIPLE agent_start/message_end cycles before pi is genuinely
- * done responding, and the docs don't show an explicit "fully idle" event
- * distinct from message_end. This runner sends `get_state` after every
- * message_end and treats `data.isStreaming === false` as "done" — a
- * reasonable, protocol-grounded inference (get_state IS documented), but
- * NOT independently verified against a live pi install (none was available
- * here). If pi's real behavior differs, this could end a turn early or hang
- * waiting past STARTUP_GRACE_MS. Validate against a real `pi --mode rpc`
- * session before relying on this in production; fall back to plain
- * `runtime: 'pi'` if it misbehaves.
+ * Usage accounting: `agent_end.messages` includes one `assistant` entry per
+ * internal turn, each carrying that turn's OWN `usage` (confirmed live: a
+ * 4-turn run had usage.output of 65/109/13/22 across the 4 assistant
+ * entries — small, turn-scoped numbers, not a running cumulative total).
+ * This runner sums `usage.input`/`usage.output` across every assistant
+ * entry in `agent_end.messages` to get the correct total for the prompt.
+ * The PREVIOUS implementation (overwriting from `message_update`'s running
+ * total, which only tracks the CURRENT assistant message) silently
+ * undercounted any prompt that triggered more than one internal turn —
+ * confirmed via the same live test above.
  *
  * Org tools (org_send, knowledge_search, ask_human, …) — FENCE PROTOCOL:
  *   Pi's own native tools (bash, file edits) execute autonomously inside pi
  *   itself and never reach this runner — only org tools ride the shared
- *   tool-fence protocol (tool-fence.ts), extracted from message_end's text
- *   content and fed back as a new `prompt` command in the SAME session.
+ *   tool-fence protocol (tool-fence.ts), extracted from the assistant text
+ *   in `agent_end.messages` and fed back as a new `prompt` command in the
+ *   SAME session.
  */
 import { spawn } from 'node:child_process';
 import { join } from 'node:path';
 import type { AgentRunner, AgentRunArgs, AgentMessage } from './agent-runner.js';
 import { buildToolProtocol, parseToolCalls, executeToolCall, formatToolResults, MAX_TOOL_ROUNDS, TOOL_CALL_RE } from './tool-fence.js';
 
-/** Distinct from a turn timeout — this is how long we wait for pi to settle
- *  to isStreaming:false after a message_end before giving up on the
- *  heuristic and treating the turn as complete anyway (better to risk
- *  cutting a turn slightly short than to hang forever on a wrong inference). */
+/** Upper bound on how long a single prompt's wait for `agent_end` may run
+ *  before the mid-session silence watchdog (below) considers pi wedged.
+ *  Distinct from a hard per-turn deadline — a long-running prompt that's
+ *  still producing events well within this window is not a hang; only
+ *  total SILENCE past this bound is. */
 const SETTLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const STARTUP_GRACE_MS = 45_000;
 
@@ -138,7 +146,13 @@ export class PiRpcAgentRunner implements AgentRunner {
     const bin = this.piBin || process.env.PI_CLI_BIN || 'pi';
     const sessionDir = join(args.cwd, '.monomind-pi-session');
 
-    const cliArgs = ['--mode', 'rpc', '--approve', '--session-dir', sessionDir];
+    // No --approve: confirmed against a live v0.73.1 install that pi rejects
+    // it outright ("Unknown option: --approve") — no such flag exists.
+    // Confirmed unnecessary too: built-in tools (read/edit/bash) execute
+    // autonomously in --mode rpc with zero confirmation gating (a live
+    // multi-tool prompt — read, edit, bash — ran end-to-end with no prompt
+    // or block). See #179.
+    const cliArgs = ['--mode', 'rpc', '--session-dir', sessionDir];
     if (args.model) cliArgs.push('--model', args.model);
 
     const child = this.spawnFn(bin, cliArgs, {
@@ -227,7 +241,7 @@ export class PiRpcAgentRunner implements AgentRunner {
     // the check entirely for the duration is the correct fix in both cases.
     let toolCallInFlight = false;
     let turnInFlight = false;
-    const MID_SESSION_SILENCE_MS = SETTLE_TIMEOUT_MS; // reuse the same bound the settle-heuristic gives up at
+    const MID_SESSION_SILENCE_MS = SETTLE_TIMEOUT_MS; // reuse the same bound as the ceiling for total event silence
     const silenceWatchdog: ReturnType<typeof setInterval> = setInterval(() => {
       if (closed || toolCallInFlight || !turnInFlight) return;
       if (Date.now() - lastEventAt > MID_SESSION_SILENCE_MS) {
@@ -259,21 +273,12 @@ export class PiRpcAgentRunner implements AgentRunner {
         turnLoop: for (;;) {
           send({ type: 'prompt', message: nextMessage });
 
-          const collectedText: string[] = [];
-          const settleDeadline = Date.now() + SETTLE_TIMEOUT_MS;
-          let sawMessageEnd = false;
+          let agentEndMessages: Array<{ role: string; content?: PiContentBlock[]; usage?: { input?: number; output?: number } }> | undefined;
 
           for (;;) {
             const ev = await nextEvent();
             disarmHang();
             const kind = ev.type as string | undefined;
-
-            // Checked on EVERY event, not only get_state responses — a
-            // stream of message_update/message_end events with pi never
-            // actually answering get_state (e.g. it doesn't recognize the
-            // command, or a response gets lost) would otherwise never hit
-            // the deadline check below and could wait past it indefinitely.
-            if (sawMessageEnd && Date.now() > settleDeadline) break;
 
             if (kind === '__closed__' || kind === '__error__' || kind === '__hang__') {
               if (kind === '__error__') {
@@ -295,54 +300,36 @@ export class PiRpcAgentRunner implements AgentRunner {
               );
             }
 
-            if (kind === 'message_update') {
-              // Overwrite (not accumulate) — the confirmed example in this
-              // file's header shows `usage` as a running total FOR THE
-              // CURRENT RESPONSE, so the latest value read during a turn is
-              // that turn's correct total. UNCONFIRMED: whether it's scoped
-              // to the current prompt or to the whole (session-lifetime) rpc
-              // process. If it turns out to be session-cumulative, every
-              // turn after the first would over-report by including prior
-              // turns' tokens — inflating org budget consumption. Validate
-              // against a live pi install before relying on this for tight
-              // budget enforcement; this is exactly the kind of gap opt-in
-              // 'pi-rpc' (vs. default 'pi') is meant to warn callers about.
-              const usage = ev.usage as { input?: number; output?: number } | undefined;
-              if (usage) {
-                turnInputTokens = usage.input ?? turnInputTokens;
-                turnOutputTokens = usage.output ?? turnOutputTokens;
-              }
-              continue;
+            if (kind === 'agent_end') {
+              // See file header: agent_end is pi's own, confirmed-live,
+              // single unambiguous "this prompt is fully done" signal —
+              // fires exactly once even across multiple internal
+              // turn_start/turn_end cycles from pi's own native tool use.
+              agentEndMessages = ev.messages as typeof agentEndMessages;
+              break;
             }
 
-            if (kind === 'message_end') {
-              sawMessageEnd = true;
-              const message = ev.message as PiRpcMessage | undefined;
-              if (message) {
-                const text2 = extractPiRpcText(message);
-                if (text2) collectedText.push(text2);
-              }
-              // See file header: get_state is the documented, best-effort
-              // signal for "pi is done responding to this prompt", since a
-              // single prompt can trigger multiple internal tool-use cycles.
-              send({ type: 'get_state' });
-              continue;
-            }
-
-            if (kind === 'response' && ev.command === 'get_state') {
-              const data = ev.data as { isStreaming?: boolean } | undefined;
-              if (data?.isStreaming === false) break; // turn settled — fall through to tool-fence handling below
-              if (Date.now() > settleDeadline) break; // heuristic gave up — proceed rather than hang forever
-              continue; // still streaming — keep waiting for more message_end cycles
-            }
-
-            // agent_start, other response acks, tool_execution_* (pi's own
-            // native tools — nothing for this runner to do) — ignored.
+            // agent_start, turn_start/turn_end, message_start/message_update/
+            // message_end, tool_execution_* (pi's own native tools), other
+            // response acks — all drained and ignored; agent_end alone
+            // carries everything this runner needs (final text + usage).
           }
 
-          if (!sawMessageEnd) break turnLoop; // nothing to extract this round — avoid an infinite loop on an empty settle
+          if (!agentEndMessages) break turnLoop; // process closed before agent_end — nothing to extract this round
 
-          const rawText = collectedText.join('\n');
+          const assistantMessages = agentEndMessages.filter((m) => m.role === 'assistant');
+          for (const m of assistantMessages) {
+            // Summed, not overwritten: each assistant entry carries ITS OWN
+            // per-turn usage (confirmed live — see file header), so summing
+            // across every internal turn in this agent_end is the correct
+            // total for the prompt just sent.
+            if (m.usage) {
+              turnInputTokens += m.usage.input ?? 0;
+              turnOutputTokens += m.usage.output ?? 0;
+            }
+          }
+
+          const rawText = assistantMessages.map((m) => extractPiRpcText(m)).filter(Boolean).join('\n');
           const visibleText = rawText.replace(TOOL_CALL_RE, '').trim();
           if (visibleText) yield { type: 'assistant', text: visibleText };
 


### PR DESCRIPTION
## Summary
Live-verified against a real pi v0.73.1 install (z.ai GLM-5.3 backend):
- Replaced the `get_state`-polling turn-completion heuristic with pi's documented `agent_end` event — confirmed to fire exactly once per prompt even across multiple internal native-tool-use cycles.
- Fixed a real usage-accounting bug: usage was read from `message_update`'s running total and overwritten on each update, silently capturing only the LAST internal turn instead of summing all turns in the prompt.
- Fixed a real bug: `--approve` isn't a valid pi flag (pi v0.73.1 rejects it outright), so every `PiRpcAgentRunner` invocation was failing immediately. Confirmed unnecessary — RPC mode auto-executes built-in tools.

## Test plan
- [x] `vitest run __tests__/orgrt/pi-rpc-runner.test.ts` — 16/16 passing (updated fixtures to match the confirmed protocol)
- [x] `tsc --noEmit` — no errors
- [x] Live end-to-end smoke test through `PiRpcAgentRunner.run()` (not just raw `pi`): multi-step native tool use (read → edit → bash) + an org `tool_call` fence round-trip (`org_send`), with correctly-summed non-zero token usage reported