### PR TITLE
fix(orgrt): part of #178 — codex-runner used the wrong event schema entirely

### DIFF
--- a/packages/@monomind/cli/src/__tests__/codex-runner.test.ts
+++ b/packages/@monomind/cli/src/__tests__/codex-runner.test.ts
@@ -3,7 +3,8 @@
  *
  * Tests the Codex CLI subprocess protocol parsing without requiring the actual
  * codex binary — mocks child_process.spawn and feeds it scripted JSONL events
- * matching the byte-accurate schema from openai/codex/sdk/typescript/src.
+ * matching the legacy v1 EventMsg wire format (codex-rs/protocol/src/protocol.rs
+ * + legacy_events.rs), confirmed live against codex v0.21.0/v0.147.0 (#178).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CodexAgentRunner } from '../orgrt/codex-runner.js';
@@ -29,8 +30,12 @@ function makeMockChild(stdoutLines: string[], exitCode = 0): cp.ChildProcess {
   return child as cp.ChildProcess;
 }
 
-/** Usage event helper */
-const USAGE = { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0, cache_write_input_tokens: 0, reasoning_output_tokens: 0 };
+/** token_count event helper — last_token_usage is per-turn (see file header:
+ *  the runner reads THIS field, not total_token_usage, which is cumulative). */
+const TOKEN_COUNT = {
+  type: 'token_count',
+  info: { last_token_usage: { input_tokens: 10, output_tokens: 5, cached_input_tokens: 0, cache_write_input_tokens: 0, reasoning_output_tokens: 0, total_tokens: 15 } },
+};
 
 describe('CodexAgentRunner', () => {
   let runner: CodexAgentRunner;
@@ -40,11 +45,11 @@ describe('CodexAgentRunner', () => {
     vi.clearAllMocks();
   });
 
-  it('builds correct argv: codex exec --experimental-json', async () => {
+  it('builds correct argv: codex exec --json', async () => {
     const mockChild = makeMockChild([
-      JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
-      JSON.stringify({ type: 'turn.started' }),
-      JSON.stringify({ type: 'turn.completed', usage: USAGE }),
+      JSON.stringify({ type: 'session_configured', session_id: 't1', thread_id: 't1' }),
+      JSON.stringify({ type: 'task_started' }),
+      JSON.stringify(TOKEN_COUNT),
     ]);
     vi.mocked(cp.spawn).mockReturnValue(mockChild);
 
@@ -63,7 +68,8 @@ describe('CodexAgentRunner', () => {
     const spawnArgs = vi.mocked(cp.spawn).mock.calls[0];
     expect(spawnArgs[0]).toBe('/usr/bin/codex');
     expect(spawnArgs[1]).toContain('exec');
-    expect(spawnArgs[1]).toContain('--experimental-json');
+    expect(spawnArgs[1]).toContain('--json');
+    expect(spawnArgs[1]).not.toContain('--experimental-json');
     expect(spawnArgs[1]).toContain('--model');
     expect(spawnArgs[1]).toContain('gpt-5.6-terra');
     expect(spawnArgs[1]).toContain('--sandbox');
@@ -71,10 +77,10 @@ describe('CodexAgentRunner', () => {
     expect(spawnArgs[1]).toContain('--skip-git-repo-check');
   });
 
-  it('captures thread_id from thread.started event', async () => {
+  it('captures session id from session_configured event', async () => {
     vi.mocked(cp.spawn).mockReturnValue(makeMockChild([
-      JSON.stringify({ type: 'thread.started', thread_id: 'test-thread-123' }),
-      JSON.stringify({ type: 'turn.completed', usage: USAGE }),
+      JSON.stringify({ type: 'session_configured', session_id: 'test-thread-123', thread_id: 'test-thread-123' }),
+      JSON.stringify(TOKEN_COUNT),
     ]));
 
     const gen = runner.run({
@@ -93,11 +99,11 @@ describe('CodexAgentRunner', () => {
     expect(resultMsg.session_id).toBe('test-thread-123');
   });
 
-  it('extracts agent_message text from item.completed', async () => {
+  it('extracts text from agent_message events', async () => {
     vi.mocked(cp.spawn).mockReturnValue(makeMockChild([
-      JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
-      JSON.stringify({ type: 'item.completed', item: { id: 'i1', type: 'agent_message', text: 'Hello world!' } }),
-      JSON.stringify({ type: 'turn.completed', usage: USAGE }),
+      JSON.stringify({ type: 'session_configured', session_id: 't1', thread_id: 't1' }),
+      JSON.stringify({ type: 'agent_message', message: 'Hello world!' }),
+      JSON.stringify(TOKEN_COUNT),
     ]));
 
     const gen = runner.run({
@@ -117,10 +123,16 @@ describe('CodexAgentRunner', () => {
     expect(assistantMsg.text).toBe('Hello world!');
   });
 
-  it('extracts usage from turn.completed', async () => {
+  it('extracts per-turn usage from token_count.info.last_token_usage (not the cumulative total_token_usage)', async () => {
     vi.mocked(cp.spawn).mockReturnValue(makeMockChild([
-      JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
-      JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 24763, output_tokens: 122, cached_input_tokens: 24448, cache_write_input_tokens: 0, reasoning_output_tokens: 0 } }),
+      JSON.stringify({ type: 'session_configured', session_id: 't1', thread_id: 't1' }),
+      JSON.stringify({
+        type: 'token_count',
+        info: {
+          last_token_usage: { input_tokens: 24763, output_tokens: 122, cached_input_tokens: 24448, cache_write_input_tokens: 0, reasoning_output_tokens: 0, total_tokens: 24885 },
+          total_token_usage: { input_tokens: 999999, output_tokens: 999999, cached_input_tokens: 0, cache_write_input_tokens: 0, reasoning_output_tokens: 0, total_tokens: 1999998 },
+        },
+      }),
     ]));
 
     const gen = runner.run({
@@ -140,10 +152,10 @@ describe('CodexAgentRunner', () => {
     expect(resultMsg.output_tokens).toBe(122);
   });
 
-  it('surfaces error from turn.failed event', async () => {
+  it('surfaces error from task_complete.error', async () => {
     vi.mocked(cp.spawn).mockReturnValue(makeMockChild([
-      JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
-      JSON.stringify({ type: 'turn.failed', error: { message: 'rate limited' } }),
+      JSON.stringify({ type: 'session_configured', session_id: 't1', thread_id: 't1' }),
+      JSON.stringify({ type: 'task_complete', turn_id: 'turn1', last_agent_message: null, error: { message: 'rate limited' } }),
     ]));
 
     const gen = runner.run({
@@ -160,8 +172,8 @@ describe('CodexAgentRunner', () => {
 
   it('uses resume positional arg when threadId provided', async () => {
     vi.mocked(cp.spawn).mockReturnValue(makeMockChild([
-      JSON.stringify({ type: 'thread.started', thread_id: 'existing-thread' }),
-      JSON.stringify({ type: 'turn.completed', usage: USAGE }),
+      JSON.stringify({ type: 'session_configured', session_id: 'existing-thread', thread_id: 'existing-thread' }),
+      JSON.stringify(TOKEN_COUNT),
     ]));
 
     const gen = runner.run({
@@ -214,14 +226,14 @@ describe('CodexAgentRunner', () => {
     // with no tool calls → loop ends.
     vi.mocked(cp.spawn)
       .mockReturnValueOnce(makeMockChild([
-        JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
-        JSON.stringify({ type: 'item.completed', item: { id: 'i1', type: 'agent_message', text: 'Sending...\n\n```tool_call\n{"name": "org_send", "arguments": {"to": "boss"}}\n```' } }),
-        JSON.stringify({ type: 'turn.completed', usage: USAGE }),
+        JSON.stringify({ type: 'session_configured', session_id: 't1', thread_id: 't1' }),
+        JSON.stringify({ type: 'agent_message', message: 'Sending...\n\n```tool_call\n{"name": "org_send", "arguments": {"to": "boss"}}\n```' }),
+        JSON.stringify(TOKEN_COUNT),
       ]))
       .mockReturnValueOnce(makeMockChild([
-        JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
-        JSON.stringify({ type: 'item.completed', item: { id: 'i2', type: 'agent_message', text: 'Done.' } }),
-        JSON.stringify({ type: 'turn.completed', usage: USAGE }),
+        JSON.stringify({ type: 'session_configured', session_id: 't1', thread_id: 't1' }),
+        JSON.stringify({ type: 'agent_message', message: 'Done.' }),
+        JSON.stringify(TOKEN_COUNT),
       ]));
 
     const gen = runner.run({

--- a/packages/@monomind/cli/src/orgrt/codex-runner.ts
+++ b/packages/@monomind/cli/src/orgrt/codex-runner.ts
@@ -16,18 +16,72 @@
  *   agent_message text, executes the real OrgToolDef handlers in-process
  *   (gated through canUseTool), and feeds results back as the next prompt.
  *
- * Subprocess protocol (byte-accurate from openai/codex/sdk/typescript/src):
- *   - Subcommand: `codex exec --experimental-json [--model X] [--cd Y]
- *                  [--skip-git-repo-check] [--sandbox danger-full-access]
- *                  [resume <thread_id>] "<prompt>"`
- *   - JSONL on stdout, one event per line
- *   - 8 event types: thread.started, turn.started, turn.completed,
- *     turn.failed, item.started, item.updated, item.completed, error
- *   - Assistant text arrives via item.completed with item.type === 'agent_message'
- *   - NO per-token streaming (whole items only)
- *   - Resume: positional `resume <thread_id>` (NOT a flag)
- *   - Session ID captured from thread.started.thread_id
- *   - stderr is human diagnostics; buffer and surface on non-zero exit only
+ * Subprocess protocol — REWRITTEN against openai/codex's own Rust source
+ * (issue #178). This runner previously assumed a "thread.started" /
+ * "item.completed" event shape sourced from `openai/codex/sdk/typescript`,
+ * which turned out to be a DIFFERENT wire format than what `codex exec
+ * --json` actually emits. Confirmed two ways: (1) live output from an
+ * installed codex v0.21.0 (`brew install codex`) showed events shaped like
+ * `{"id":"1","msg":{"type":"task_started"}}` — nothing resembling
+ * "thread.started"; (2) cross-checked against
+ * `codex-rs/protocol/src/protocol.rs`'s `EventMsg` enum
+ * (`#[serde(tag = "type", rename_all = "snake_case")]`) and
+ * `codex-rs/protocol/src/legacy_events.rs`, which is EXACTLY this wire
+ * format and is explicitly comment-labeled "v1 wire format" (still the
+ * live default for `--json`, not a deprecated relic).
+ *
+ *   - Invocation: `codex exec --json [--model X] [--cd Y]
+ *                 [--skip-git-repo-check] [--sandbox danger-full-access]
+ *                 [resume <sessionId> "<prompt>"]`. `--experimental-json`
+ *     (the old flag name) doesn't exist in v0.21.0 — confirmed live
+ *     ("unexpected argument '--experimental-json' found"); `--json` is
+ *     correct in both v0.21.0 and the current v0.147.0 (where
+ *     `--experimental-json` IS an alias again, per current
+ *     `codex-rs/exec/src/cli.rs` — but v0.21.0 predates that alias).
+ *   - `resume` is a SUBCOMMAND of `exec`, not a positional after other exec
+ *     flags in isolation — `codex exec resume <sessionId> ["<prompt>"]`,
+ *     with `exec`'s own global flags (--json, --model, --sandbox, etc.)
+ *     specified BEFORE the `resume` token. Confirmed live (v0.147.0) that
+ *     this exact arg order parses cleanly — it got past all argument
+ *     parsing straight to an (unrelated, expired-token) auth error, not a
+ *     flag/subcommand error. v0.21.0 has no `resume` subcommand at all
+ *     (confirmed live: "resume" was consumed as the PROMPT text itself,
+ *     then the actual session id was rejected as an unexpected extra
+ *     positional) — so resume silently can't work pre-~v0.12x. This runner
+ *     doesn't detect codex's version; if resume fails on an old install,
+ *     each turn falls back to a fresh (contextless) session rather than
+ *     erroring — a real limitation, not fixed here.
+ *   - JSONL on stdout, one event per line. Confirmed real EventMsg variants
+ *     (source: `EventMsg` enum + each variant's struct, all in
+ *     `protocol.rs`):
+ *       {"type":"session_configured","session_id":"...","thread_id":"...",
+ *        "model":"...",...}                            — session/thread id
+ *       {"type":"task_started"}                          — turn started
+ *       {"type":"agent_message","message":"...","phase":...}
+ *                                                         — assistant text
+ *       {"type":"token_count","info":{"last_token_usage":
+ *        {"input_tokens":N,"output_tokens":N,"reasoning_output_tokens":N,
+ *         "total_tokens":N,...},"total_token_usage":{...}},...}
+ *                       — `last_token_usage` is per-TURN (not cumulative);
+ *                         `total_token_usage` IS cumulative — use the former
+ *       {"type":"task_complete","turn_id":"...",
+ *        "last_agent_message":"...","error":{"message":"..."}|absent,...}
+ *       {"type":"error","message":"...",...}
+ *   - NO per-token streaming in this event set (whole agent_message events
+ *     only, unlike the discarded thread/item assumption).
+ *   - Session ID: captured from `session_configured.session_id` (or
+ *     `.thread_id` — both present, same value in observed live output),
+ *     NOT from a "thread.started" event, which doesn't exist in this
+ *     protocol.
+ *   - stderr is human diagnostics; buffer and surface on non-zero exit only.
+ *
+ * STILL UNVERIFIED end-to-end (this environment's ~/.codex/auth.json had a
+ * dead refresh token — "refresh token was already used... sign in again" —
+ * needs a fresh `codex login`, not something driven here): a full
+ * successful `task_complete`/`token_count` pair was never actually
+ * observed. The struct field names above are taken directly from the Rust
+ * source (high confidence, not a guess), but a live confirmation of the
+ * exact JSON once auth works would still be worthwhile.
  */
 import { spawn } from 'node:child_process';
 import type { AgentRunner, AgentRunArgs, AgentMessage } from './agent-runner.js';
@@ -35,27 +89,38 @@ import { buildToolProtocol, parseToolCalls, executeToolCall, formatToolResults, 
 
 const TURN_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours, matching kimi runner
 
-interface CodexItem {
-  id: string;
-  type: 'agent_message' | 'reasoning' | 'command_execution' | 'file_change' | 'mcp_tool_call' | 'web_search' | 'todo_list' | 'error';
-  text?: string;
-  message?: string;
-  [key: string]: unknown;
+/** `EventMsg`'s legacy v1 wire format — see file header for the source
+ *  citation (codex-rs/protocol/src/protocol.rs + legacy_events.rs). Only
+ *  the variants this runner acts on are typed; everything else (exec
+ *  command begin/end, mcp tool call begin/end, reasoning, …) is ignored. */
+interface CodexTokenUsage {
+  input_tokens: number;
+  cached_input_tokens?: number;
+  cache_write_input_tokens?: number;
+  output_tokens: number;
+  reasoning_output_tokens?: number;
+  total_tokens?: number;
 }
 
 interface CodexEvent {
-  type: 'thread.started' | 'turn.started' | 'turn.completed' | 'turn.failed' | 'item.started' | 'item.updated' | 'item.completed' | 'error';
+  type:
+    | 'session_configured'
+    | 'task_started'
+    | 'agent_message'
+    | 'token_count'
+    | 'task_complete'
+    | 'error';
+  // session_configured
+  session_id?: string;
   thread_id?: string;
-  item?: CodexItem;
-  usage?: {
-    input_tokens: number;
-    cached_input_tokens: number;
-    cache_write_input_tokens: number;
-    output_tokens: number;
-    reasoning_output_tokens: number;
-  };
-  error?: { message: string };
+  // agent_message
   message?: string;
+  // token_count
+  info?: { last_token_usage?: CodexTokenUsage; total_token_usage?: CodexTokenUsage };
+  // task_complete
+  turn_id?: string;
+  last_agent_message?: string;
+  error?: { message: string };
 }
 
 interface TurnOutcome {
@@ -169,11 +234,11 @@ export class CodexAgentRunner implements AgentRunner {
     args: AgentRunArgs,
   ): Promise<TurnOutcome> {
     return new Promise<TurnOutcome>((resolve, reject) => {
-      // ARG ORDER (byte-accurate from codex SDK source):
-      //   codex exec --experimental-json [--model X] [--cd Y]
+      // ARG ORDER — see file header for the live-verified citation:
+      //   codex exec --json [--model X] [--cd Y]
       //              [--skip-git-repo-check] [--sandbox danger-full-access]
       //              [resume <threadId>] "<prompt>"
-      const cliArgs: string[] = ['exec', '--experimental-json'];
+      const cliArgs: string[] = ['exec', '--json'];
       if (args.model) cliArgs.push('--model', args.model);
       cliArgs.push('--cd', args.cwd);
       cliArgs.push('--skip-git-repo-check');
@@ -236,15 +301,21 @@ export class CodexAgentRunner implements AgentRunner {
             inputTokens: 0, outputTokens: 0,
           };
           for (const ev of events) {
-            if (ev.type === 'thread.started' && ev.thread_id) {
-              outcome.threadId = ev.thread_id;
-            } else if (ev.type === 'item.completed' && ev.item?.type === 'agent_message' && ev.item.text) {
-              outcome.rawTexts.push(ev.item.text);
-            } else if (ev.type === 'turn.completed' && ev.usage) {
-              outcome.inputTokens = ev.usage.input_tokens ?? 0;
-              outcome.outputTokens = ev.usage.output_tokens ?? 0;
-            } else if (ev.type === 'turn.failed' && ev.error) {
-              outcome.error = ev.error.message;
+            if (ev.type === 'session_configured' && (ev.session_id || ev.thread_id)) {
+              outcome.threadId = ev.session_id ?? ev.thread_id;
+            } else if (ev.type === 'agent_message' && ev.message) {
+              outcome.rawTexts.push(ev.message);
+            } else if (ev.type === 'token_count' && ev.info?.last_token_usage) {
+              // last_token_usage is per-TURN; total_token_usage is
+              // cumulative for the whole session — using the latter here
+              // would over-report on every turn after the first.
+              outcome.inputTokens = ev.info.last_token_usage.input_tokens ?? 0;
+              outcome.outputTokens = ev.info.last_token_usage.output_tokens ?? 0;
+            } else if (ev.type === 'task_complete') {
+              if (ev.error) outcome.error = ev.error.message;
+              // last_agent_message is a convenience summary already covered
+              // by the agent_message events collected above — not pushed
+              // again here to avoid duplicating the same text.
             } else if (ev.type === 'error' && ev.message) {
               outcome.error = ev.message;
             }


### PR DESCRIPTION
## Summary
Live + source-verified against codex v0.21.0 (this environment's `brew`-installed version) and v0.147.0 (current npm release, tested in isolation without touching the brew install):

- `--experimental-json` doesn't exist in v0.21.0 ("unexpected argument" live) — it's only an alias added back in later versions. Fixed to `--json`, confirmed working in both versions.
- **Bigger finding**: the runner's entire event schema (`thread.started`/`item.completed`/`turn.completed`) doesn't match what `codex exec --json` actually emits. Live output showed `{"id":"1","msg":{"type":"task_started"}}`-shaped events. Cross-checked against `codex-rs/protocol/src/protocol.rs`'s `EventMsg` enum (explicitly labeled "v1 wire format" — the live default, not deprecated) and rewrote the parser to match: `session_configured` (session id), `agent_message` (text), `token_count.info.last_token_usage` (per-turn usage — the runner previously would have silently reported 0 forever, or worse, over-reported via the cumulative field), `task_complete`, `error`.
- Fixed session id extraction (was reading an event that never fires).
- `resume` is a subcommand of `exec`, not a bare positional — confirmed live (v0.147.0) this arg order parses cleanly; also confirmed it doesn't exist at all in v0.21.0.

**Not fully live-confirmed end-to-end**: this environment's `~/.codex/auth.json` has a dead refresh token ("already been used... sign in again") — needs a fresh `codex login`, not driven here. Field names are taken directly from Rust source (high confidence), but a live successful `task_complete`/`token_count` pair was never actually observed.

## Test plan
- [x] `vitest run src/__tests__/codex-runner.test.ts` — 8/8 passing (fixtures rewritten to match confirmed schema)
- [x] `tsc --noEmit` — no errors
- [x] Live CLI flag/subcommand parsing confirmed against both v0.21.0 and v0.147.0 (got past all argument parsing to auth-only errors)