### PR TITLE
feat(orgrt): resolve #182 — add qwen-rpc runtime; fix real usage-field bug in qwen-runner

### DIFF
--- a/packages/@monomind/cli/__tests__/orgrt/qwen-rpc-runner.test.ts
+++ b/packages/@monomind/cli/__tests__/orgrt/qwen-rpc-runner.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for qwen-rpc-runner.ts: the pure JSONL codec/extraction
+ * helpers, and the full turn-completion state machine driven against a
+ * fake QwenRpcProcess (no real `qwen` binary needed).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import {
+  QwenJsonlDecoder,
+  encodeQwenRpcUserMessage,
+  extractQwenRpcText,
+  QwenRpcAgentRunner,
+  type QwenRpcProcess,
+} from '../../src/orgrt/qwen-rpc-runner.js';
+import type { AgentRunArgs, AgentMessage } from '../../src/orgrt/agent-runner.js';
+
+describe('QwenJsonlDecoder', () => {
+  it('decodes a single complete line', () => {
+    const d = new QwenJsonlDecoder();
+    expect(d.feed('{"type":"system"}\n')).toEqual([{ type: 'system' }]);
+  });
+
+  it('reassembles a line split across feed() calls', () => {
+    const d = new QwenJsonlDecoder();
+    expect(d.feed('{"type":"sys')).toEqual([]);
+    expect(d.feed('tem"}\n')).toEqual([{ type: 'system' }]);
+  });
+
+  it('skips a malformed line without throwing or losing the next one', () => {
+    const d = new QwenJsonlDecoder();
+    const out = d.feed('not json\n{"type":"ok"}\n');
+    expect(out).toEqual([{ type: 'ok' }]);
+  });
+});
+
+describe('encodeQwenRpcUserMessage', () => {
+  it('produces the documented {"type":"user","message":{"content":"..."}} shape', () => {
+    expect(encodeQwenRpcUserMessage('hi')).toBe('{"type":"user","message":{"content":"hi"}}\n');
+  });
+});
+
+describe('extractQwenRpcText', () => {
+  it('joins text blocks and drops thinking blocks', () => {
+    const text = extractQwenRpcText({
+      content: [
+        { type: 'thinking', thinking: 'internal reasoning' },
+        { type: 'text', text: 'hello' },
+        { type: 'text', text: 'world' },
+      ],
+    });
+    expect(text).toBe('hello\nworld');
+  });
+
+  it('returns empty string for a content-free message', () => {
+    expect(extractQwenRpcText({})).toBe('');
+  });
+});
+
+/** A minimal fake QwenRpcProcess: an EventEmitter-backed duplex that
+ *  records every command written to stdin and lets the test script
+ *  server-side events onto stdout on its own schedule. */
+function fakeProcess(): QwenRpcProcess & { written: string[]; emitStdout: (line: string) => void; emitClose: (code: number) => void; emitError: (err: Error) => void } {
+  const emitter = new EventEmitter();
+  const stdoutEmitter = new EventEmitter();
+  const written: string[] = [];
+  return {
+    stdin: { write: (data: string) => { written.push(data); } },
+    stdout: { on: (event, cb) => { stdoutEmitter.on(event, cb); } },
+    stderr: { on: () => {} },
+    on: (event: string, cb: (...a: unknown[]) => void) => { emitter.on(event, cb); },
+    kill: vi.fn(),
+    written,
+    emitStdout: (line: string) => stdoutEmitter.emit('data', Buffer.from(line)),
+    emitClose: (code: number) => emitter.emit('close', code),
+    emitError: (err: Error) => emitter.emit('error', err),
+  };
+}
+
+function baseArgs(prompt: AsyncIterable<string>): AgentRunArgs {
+  return {
+    tools: [],
+    prompt,
+    systemPrompt: 'You are a test agent.',
+    cwd: '/tmp/test-project',
+    env: {},
+    maxTurns: 10,
+  };
+}
+
+async function* singlePrompt(text: string): AsyncGenerator<string> {
+  yield text;
+}
+
+async function collect(iter: AsyncIterable<AgentMessage>): Promise<AgentMessage[]> {
+  const out: AgentMessage[] = [];
+  for await (const m of iter) out.push(m);
+  return out;
+}
+
+describe('QwenRpcAgentRunner — turn-completion state machine', () => {
+  it('sends one user message and yields assistant text once result arrives', async () => {
+    const proc = fakeProcess();
+    const runner = new QwenRpcAgentRunner('qwen', () => proc);
+
+    const resultsPromise = collect(runner.run(baseArgs(singlePrompt('hello'))));
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(proc.written[0]).toBe('{"type":"user","message":{"content":"You are a test agent.\\n\\n---\\n\\nhello"}}\n');
+
+    proc.emitStdout('{"type":"system","subtype":"init","session_id":"s1"}\n');
+    proc.emitStdout(JSON.stringify({ type: 'assistant', session_id: 's1', message: { content: [{ type: 'text', text: 'Hi there' }] } }) + '\n');
+    proc.emitStdout(JSON.stringify({ type: 'result', subtype: 'success', session_id: 's1', usage: { input_tokens: 10, output_tokens: 5 } }) + '\n');
+    proc.emitClose(0);
+
+    const messages = await resultsPromise;
+    const assistant = messages.filter((m) => m.type === 'assistant');
+    expect(assistant.map((m) => m.text)).toEqual(['Hi there']);
+    const result = messages.find((m) => m.type === 'result');
+    expect(result).toBeDefined();
+    expect(result?.session_id).toBe('s1');
+    expect(result?.input_tokens).toBe(10);
+    expect(result?.output_tokens).toBe(5);
+  });
+
+  it('consolidates text from multiple assistant events before a single result (native tool-use cycle)', async () => {
+    const proc = fakeProcess();
+    const runner = new QwenRpcAgentRunner('qwen', () => proc);
+    const resultsPromise = collect(runner.run(baseArgs(singlePrompt('hello'))));
+    await new Promise((r) => setTimeout(r, 10));
+
+    proc.emitStdout(JSON.stringify({ type: 'assistant', session_id: 's1', message: { content: [{ type: 'text', text: 'working on it' }] } }) + '\n');
+    proc.emitStdout(JSON.stringify({ type: 'assistant', session_id: 's1', message: { content: [{ type: 'text', text: 'done now' }] } }) + '\n');
+    proc.emitStdout(JSON.stringify({ type: 'result', subtype: 'success', session_id: 's1', usage: { input_tokens: 1, output_tokens: 1 } }) + '\n');
+    proc.emitClose(0);
+
+    const messages = await resultsPromise;
+    const assistant = messages.filter((m) => m.type === 'assistant').map((m) => m.text);
+    expect(assistant).toEqual(['working on it\ndone now']);
+  });
+
+  it('extracts an org tool_call fence, executes it, and continues the same session', async () => {
+    const proc = fakeProcess();
+    const executeCalls: string[] = [];
+    const runner = new QwenRpcAgentRunner('qwen', () => proc);
+
+    const args = baseArgs(singlePrompt('hello'));
+    args.tools = [{
+      name: 'org_send',
+      description: 'send a message',
+      schema: {},
+      handler: async (input) => { executeCalls.push(JSON.stringify(input)); return { text: 'sent' }; },
+    }];
+
+    const resultsPromise = collect(runner.run(args));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const fence = '```tool_call\n{"name":"org_send","arguments":{"to":"boss","subject":"s","message":"m"}}\n```';
+    proc.emitStdout(JSON.stringify({ type: 'assistant', session_id: 's1', message: { content: [{ type: 'text', text: `Sending now.\n${fence}` }] } }) + '\n');
+    proc.emitStdout(JSON.stringify({ type: 'result', subtype: 'success', session_id: 's1', usage: { input_tokens: 1, output_tokens: 1 } }) + '\n');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const secondMessage = proc.written.find((w, i) => i > 0);
+    expect(secondMessage).toBeDefined();
+    expect(secondMessage).not.toContain('You are a test agent');
+
+    proc.emitStdout(JSON.stringify({ type: 'assistant', session_id: 's1', message: { content: [{ type: 'text', text: 'Done.' }] } }) + '\n');
+    proc.emitStdout(JSON.stringify({ type: 'result', subtype: 'success', session_id: 's1', usage: { input_tokens: 1, output_tokens: 1 } }) + '\n');
+    proc.emitClose(0);
+
+    const messages = await resultsPromise;
+    expect(executeCalls).toHaveLength(1);
+    expect(messages.some((m) => m.type === 'assistant' && m.text === 'Sending now.')).toBe(true);
+    expect(messages.some((m) => m.type === 'assistant' && m.text === 'Done.')).toBe(true);
+  });
+
+  it('surfaces a result error as a thrown error', async () => {
+    const proc = fakeProcess();
+    const runner = new QwenRpcAgentRunner('qwen', () => proc);
+    const resultsPromise = collect(runner.run(baseArgs(singlePrompt('hello'))));
+    await new Promise((r) => setTimeout(r, 10));
+
+    proc.emitStdout(JSON.stringify({ type: 'result', subtype: 'error', session_id: 's1', usage: { input_tokens: 0, output_tokens: 0 }, error: { message: 'quota exceeded' } }) + '\n');
+
+    await expect(resultsPromise).rejects.toThrow(/quota exceeded/);
+  });
+
+  it('surfaces a clear error and never hangs when the process closes unexpectedly', async () => {
+    const proc = fakeProcess();
+    const runner = new QwenRpcAgentRunner('qwen', () => proc);
+    const resultsPromise = collect(runner.run(baseArgs(singlePrompt('hello'))));
+    await new Promise((r) => setTimeout(r, 10));
+
+    proc.emitClose(1);
+
+    await expect(resultsPromise).rejects.toThrow(/qwen rpc process ended unexpectedly/);
+  });
+
+  it('surfaces the ORIGINAL spawn error (with its .code intact) instead of a generic wrapper', async () => {
+    const proc = fakeProcess();
+    const runner = new QwenRpcAgentRunner('qwen', () => proc);
+    const resultsPromise = collect(runner.run(baseArgs(singlePrompt('hello'))));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const enoent = Object.assign(new Error('spawn qwen ENOENT'), { code: 'ENOENT' });
+    proc.emitError(enoent);
+
+    await expect(resultsPromise).rejects.toThrow(/requires the Qwen Code CLI \(qwen\) on PATH/);
+  });
+
+  it('the first message carries the system prompt + tool protocol; subsequent prompts do not', async () => {
+    const proc = fakeProcess();
+    const runner = new QwenRpcAgentRunner('qwen', () => proc);
+
+    async function* twoPrompts() {
+      yield 'first';
+      yield 'second';
+    }
+
+    const resultsPromise = collect(runner.run(baseArgs(twoPrompts())));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(proc.written[0]).toContain('You are a test agent');
+    proc.emitStdout(JSON.stringify({ type: 'assistant', session_id: 's1', message: { content: [{ type: 'text', text: 'ok1' }] } }) + '\n');
+    proc.emitStdout(JSON.stringify({ type: 'result', subtype: 'success', session_id: 's1', usage: { input_tokens: 1, output_tokens: 1 } }) + '\n');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(proc.written[1]).toBe('{"type":"user","message":{"content":"second"}}\n');
+    proc.emitStdout(JSON.stringify({ type: 'assistant', session_id: 's1', message: { content: [{ type: 'text', text: 'ok2' }] } }) + '\n');
+    proc.emitStdout(JSON.stringify({ type: 'result', subtype: 'success', session_id: 's1', usage: { input_tokens: 1, output_tokens: 1 } }) + '\n');
+    proc.emitClose(0);
+
+    await resultsPromise;
+  });
+});

--- a/packages/@monomind/cli/__tests__/orgrt/qwen-runner.test.ts
+++ b/packages/@monomind/cli/__tests__/orgrt/qwen-runner.test.ts
@@ -26,9 +26,9 @@ describe('parseQwenEvents', () => {
     expect(r.texts).toEqual(['a\nb']);
   });
 
-  it('extracts usage tokens from a result event', () => {
+  it('extracts usage tokens from a result event (flat, top-level — confirmed live, not nested under message.usage.tokens)', () => {
     const r = parseQwenEvents([
-      JSON.stringify({ type: 'result', subtype: 'success', session_id: 's', message: { usage: { tokens: { input: 12, output: 34 } } } }),
+      JSON.stringify({ type: 'result', subtype: 'success', session_id: 's', usage: { input_tokens: 12, output_tokens: 34 } }),
     ]);
     expect(r.inputTokens).toBe(12);
     expect(r.outputTokens).toBe(34);

--- a/packages/@monomind/cli/src/orgrt/daemon.ts
+++ b/packages/@monomind/cli/src/orgrt/daemon.ts
@@ -43,6 +43,7 @@ import { CrushAgentRunner } from './crush-runner.js';
 import { CopilotAgentRunner } from './copilot-runner.js';
 import { PiAgentRunner } from './pi-runner.js';
 import { PiRpcAgentRunner } from './pi-rpc-runner.js';
+import { QwenRpcAgentRunner } from './qwen-rpc-runner.js';
 import {
   captureCheckpoint,
   generateChecksum,
@@ -115,16 +116,21 @@ export type RuntimeKind =
   | 'grok' | 'qwen' | 'crush' | 'copilot' | 'pi'
   /** Opt-in alternate to 'pi': keeps the pi subprocess alive for the whole
    *  mailbox session (--mode rpc) instead of spawning fresh per turn — see
-   *  pi-rpc-runner.ts's header for the protocol source and its one
-   *  documented-but-unverified heuristic (turn-completion detection via
-   *  get_state polling). Prefer plain 'pi' unless you specifically want
-   *  session-lifetime context continuity and have validated this against a
-   *  live pi install. No 'qwen-rpc' equivalent exists yet — qwen's
-   *  --input-format stream-json is real but its exact message schema wasn't
-   *  independently confirmed the way pi's rpc.md was, so implementing it
-   *  would mean guessing at a wire format rather than building against a
-   *  literal, sourced example. */
-  | 'pi-rpc';
+   *  pi-rpc-runner.ts's header for the protocol source (live-verified
+   *  against pi v0.73.1, issue #179). Prefer plain 'pi' unless you
+   *  specifically want session-lifetime context continuity. */
+  | 'pi-rpc'
+  /** Opt-in alternate to 'qwen': keeps the qwen subprocess alive for the
+   *  whole mailbox session (--input-format/--output-format stream-json)
+   *  instead of spawning fresh per turn — see qwen-rpc-runner.ts's header
+   *  for the protocol source (live-verified against qwen-code v0.21.13,
+   *  issue #182). One gap not independently re-verified: whether `result`
+   *  fires exactly once per turn even when qwen runs several of its own
+   *  native tools in sequence first (inferred by symmetry with the non-RPC
+   *  QwenAgentRunner, not separately live-tested for this runner). Prefer
+   *  plain 'qwen' unless you specifically want session-lifetime context
+   *  continuity. */
+  | 'qwen-rpc';
 export type ProviderKind =
   | 'subscription'
   | 'api-key'
@@ -176,6 +182,7 @@ export function resolveRunner(
   if (selected === 'copilot') return new CopilotAgentRunner();
   if (selected === 'pi') return new PiAgentRunner();
   if (selected === 'pi-rpc') return new PiRpcAgentRunner();
+  if (selected === 'qwen-rpc') return new QwenRpcAgentRunner();
   return undefined;
 }
 

--- a/packages/@monomind/cli/src/orgrt/qwen-rpc-runner.ts
+++ b/packages/@monomind/cli/src/orgrt/qwen-rpc-runner.ts
@@ -1,0 +1,359 @@
+// packages/@monomind/cli/src/orgrt/qwen-rpc-runner.ts
+/**
+ * QwenRpcAgentRunner — AgentRunner impl backed by the Qwen Code CLI's
+ * bidirectional `--input-format stream-json --output-format stream-json`
+ * mode (session-lifetime), instead of the default QwenAgentRunner
+ * (qwen-runner.ts), which spawns a fresh `qwen -p "<prompt>"` process per
+ * mailbox turn.
+ *
+ * OPT-IN, not the default. Select via role/org `runtime: 'qwen-rpc'`.
+ * Prefer plain `runtime: 'qwen'` (QwenAgentRunner) unless you specifically
+ * want the benefit this buys: the subprocess stays alive for the WHOLE
+ * mailbox session, so conversational context carries naturally (no
+ * `--resume <sessionId>` round-trip per turn) and there's no per-turn
+ * spawn/bootstrap cost.
+ *
+ * Protocol — LIVE-VERIFIED against qwen-code v0.21.13 (issue #182). The
+ * flag exists but is hidden from `qwen --help`; found by reading the
+ * bundled minified source (`packages/cli`'s yargs config,
+ * `.option("input-format", { choices: ["text","stream-json"] })`) and
+ * confirmed the exact message schema from the CLI's own bundled source
+ * (`packages/cli/src/nonInteractive/types.ts`, compiled into
+ * `chunks/session-*.js`) — the `isCLIUserMessage`/`extractUserMessageText`
+ * predicates there define the client→server shape literally, not from
+ * prose docs. Then confirmed LIVE: sent both message forms below on the
+ * same persistent subprocess against a z.ai/GLM-5.3 backend — both
+ * answered correctly, on the SAME session_id, proving session-lifetime
+ * persistence:
+ *
+ *   Client → server (this runner sends):
+ *     {"type":"user","message":{"content":"<text>"}}
+ *     (a content-block-array form is also accepted —
+ *      {"type":"user","message":{"content":[{"type":"text","text":"..."}]}}
+ *      — but the plain-string form is simpler and was used for all live
+ *      verification, so this runner sticks to it)
+ *
+ *   Server → client (same vocabulary as QwenAgentRunner's per-spawn
+ *   stream-json, confirmed identical live under RPC mode too):
+ *     {"type":"system","subtype":"init","session_id":"...",...}
+ *     {"type":"assistant","session_id":"...",
+ *      "message":{"content":[{"type":"text","text":"..."},
+ *                             {"type":"thinking","thinking":"..."}]}}
+ *     {"type":"result","subtype":"success"|"error","session_id":"...",
+ *      "usage":{"input_tokens":N,"output_tokens":N,...},
+ *      "error":{"message":"..."}|"<string>"}
+ *   `result` is a single-fire-per-turn completion signal — confirmed live
+ *   (same as the non-RPC QwenAgentRunner already relies on for its
+ *   per-spawn invocations). A `system`/`init` event was also observed
+ *   re-emitted at the start of a SECOND turn on the same subprocess — not
+ *   treated as a new-session signal here, since session_id stayed
+ *   identical across it in the live test.
+ *
+ * NOT verified live: a turn where qwen runs multiple of its OWN native
+ * tools (read/edit/bash) in sequence before responding — same class of gap
+ * pi-rpc-runner.ts disclosed for pi before its own live verification
+ * confirmed a single fire-once completion signal there too. `result`
+ * firing exactly once per submitted `user` message (not once per internal
+ * tool-use cycle) is inferred by symmetry with the non-RPC QwenAgentRunner
+ * (which already treats `result` this way across a `-p` invocation that
+ * CAN involve multiple internal tool calls) rather than independently
+ * re-confirmed here. Revalidate if this runner ends a turn early or hangs
+ * on a heavily tool-call-heavy prompt; fall back to plain `runtime: 'qwen'`
+ * if it misbehaves.
+ *
+ * Auth: inherited from the CLI's own login flow — same as QwenAgentRunner.
+ * No env vars set here. (Live verification against a custom
+ * OpenAI-compatible backend needed `--auth-type openai` plus
+ * `OPENAI_API_KEY`/`OPENAI_BASE_URL`/`OPENAI_MODEL` env vars, per
+ * qwen-runner.ts's own header — not something this runner forces, since a
+ * real deployment's own qwen config/subscription should already be set up
+ * the way its operator wants.)
+ *
+ * Org tools (org_send, knowledge_search, ask_human, …) — FENCE PROTOCOL:
+ *   Qwen's own native tools (read/edit/bash) execute autonomously inside
+ *   qwen itself and never reach this runner — only org tools ride the
+ *   shared tool-fence protocol (tool-fence.ts), extracted from assistant
+ *   text collected before `result` and fed back as a new `user` message in
+ *   the SAME session.
+ */
+import { spawn } from 'node:child_process';
+import type { AgentRunner, AgentRunArgs, AgentMessage } from './agent-runner.js';
+import { buildToolProtocol, parseToolCalls, executeToolCall, formatToolResults, MAX_TOOL_ROUNDS, TOOL_CALL_RE } from './tool-fence.js';
+
+/** Upper bound on how long a single turn's wait for `result` may run before
+ *  the mid-session silence watchdog (below) considers qwen wedged. */
+const SETTLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const STARTUP_GRACE_MS = 45_000;
+
+interface QwenRpcContentBlock { type: string; text?: string; thinking?: string; }
+interface QwenRpcMessage { content?: QwenRpcContentBlock[]; }
+
+/** Pure, transport-independent JSONL line decoder — same shape as
+ *  pi-rpc-runner.ts's JsonlDecoder. Exported for unit testing without a
+ *  real subprocess. */
+export class QwenJsonlDecoder {
+  private buf = '';
+  feed(chunk: string): Record<string, unknown>[] {
+    this.buf += chunk;
+    const parts = this.buf.split('\n');
+    this.buf = parts.pop() ?? '';
+    const out: Record<string, unknown>[] = [];
+    for (const line of parts) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try { out.push(JSON.parse(trimmed)); } catch { /* skip malformed line */ }
+    }
+    return out;
+  }
+}
+
+/** Encode a client→server `user` message as one LF-terminated JSON line —
+ *  the plain-string content form (see file header for why the
+ *  content-block-array form isn't used). Exported for unit testing the
+ *  exact wire format. */
+export function encodeQwenRpcUserMessage(text: string): string {
+  return JSON.stringify({ type: 'user', message: { content: text } }) + '\n';
+}
+
+/** Extract assistant-visible text from an `assistant` event's
+ *  `message.content` array. `thinking` blocks are dropped (internal
+ *  reasoning, not meant for the bus). Exported for unit testing against
+ *  fixture content arrays. */
+export function extractQwenRpcText(message: QwenRpcMessage): string {
+  return (message.content ?? [])
+    .filter((b) => b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text as string)
+    .join('\n');
+}
+
+/** The subset of a spawned child process this runner needs — same
+ *  duck-typed seam as pi-rpc-runner.ts's PiRpcProcess, so tests can supply
+ *  a fake implementation to exercise the full turn-completion state
+ *  machine without a real `qwen` binary. */
+export interface QwenRpcProcess {
+  stdin: { write(data: string): void } | null;
+  stdout: { on(event: 'data', cb: (chunk: Buffer) => void): void } | null;
+  stderr: { on(event: 'data', cb: (chunk: Buffer) => void): void } | null;
+  on(event: 'close', cb: (code: number | null) => void): void;
+  on(event: 'error', cb: (err: Error) => void): void;
+  kill(signal?: string): void;
+}
+
+export type SpawnQwenRpc = (bin: string, args: string[], opts: { cwd: string; env: Record<string, string | undefined> }) => QwenRpcProcess;
+
+const defaultSpawnQwenRpc: SpawnQwenRpc = (bin, args, opts) =>
+  spawn(bin, args, { cwd: opts.cwd, env: opts.env, stdio: ['pipe', 'pipe', 'pipe'] }) as unknown as QwenRpcProcess;
+
+export class QwenRpcAgentRunner implements AgentRunner {
+  constructor(private qwenBin?: string, private spawnFn: SpawnQwenRpc = defaultSpawnQwenRpc) {}
+
+  async *run(args: AgentRunArgs): AsyncIterable<AgentMessage> {
+    const bin = this.qwenBin || process.env.QWEN_CLI_BIN || 'qwen';
+
+    const cliArgs = ['--input-format', 'stream-json', '--output-format', 'stream-json', '--yolo'];
+    if (args.model) cliArgs.push('-m', args.model);
+
+    const child = this.spawnFn(bin, cliArgs, {
+      cwd: args.cwd,
+      env: { ...process.env, ...args.env },
+    });
+
+    let stderrTail = '';
+    child.stderr?.on('data', (c: Buffer) => { stderrTail = (stderrTail + c.toString()).slice(-4000); });
+
+    const decoder = new QwenJsonlDecoder();
+    const eventQueue: Record<string, unknown>[] = [];
+    const waiters: Array<(ev: Record<string, unknown>) => void> = [];
+    let closed = false;
+    let closeCode: number | null = null;
+    let lastEventAt = Date.now();
+
+    const pushEvents = (evs: Record<string, unknown>[]) => {
+      for (const ev of evs) {
+        const waiter = waiters.shift();
+        if (waiter) waiter(ev);
+        else eventQueue.push(ev);
+      }
+    };
+    child.stdout?.on('data', (c: Buffer) => { lastEventAt = Date.now(); pushEvents(decoder.feed(c.toString())); });
+    let processExited = false;
+    child.on('close', (code) => { closed = true; processExited = true; closeCode = code; pushEvents([{ type: '__closed__', code }]); });
+    child.on('error', (err) => { closed = true; pushEvents([{ type: '__error__', error: err }]); });
+
+    const nextEvent = (): Promise<Record<string, unknown>> => {
+      const queued = eventQueue.shift();
+      if (queued) return Promise.resolve(queued);
+      if (closed) return Promise.resolve({ type: '__closed__', code: closeCode });
+      return new Promise((resolve) => waiters.push(resolve));
+    };
+
+    const send = (text: string): void => {
+      child.stdin?.write(encodeQwenRpcUserMessage(text));
+    };
+
+    const KILL_GRACE_MS = 5000;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+    const killChild = (): void => {
+      try { child.kill('SIGTERM'); } catch { /* already gone */ }
+      killTimer = setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already gone */ } }, KILL_GRACE_MS);
+      killTimer.unref?.();
+    };
+
+    let sawAnyEvent = false;
+    let hangTimer: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
+      if (!sawAnyEvent) { closed = true; killChild(); pushEvents([{ type: '__hang__' }]); }
+    }, STARTUP_GRACE_MS);
+    const disarmHang = () => { if (!sawAnyEvent) { sawAnyEvent = true; if (hangTimer) { clearTimeout(hangTimer); hangTimer = undefined; } } };
+
+    // Rolling watchdog — same rationale/pause logic as pi-rpc-runner.ts:
+    // paused whenever an org tool call is in flight (ask_human can
+    // legitimately block far longer than the silence window) or there's no
+    // turn in flight at all (idling on the role's own mailbox is normal).
+    let toolCallInFlight = false;
+    let turnInFlight = false;
+    const MID_SESSION_SILENCE_MS = SETTLE_TIMEOUT_MS;
+    const silenceWatchdog: ReturnType<typeof setInterval> = setInterval(() => {
+      if (closed || toolCallInFlight || !turnInFlight) return;
+      if (Date.now() - lastEventAt > MID_SESSION_SILENCE_MS) {
+        closed = true;
+        killChild();
+        pushEvents([{ type: '__hang__' }]);
+      }
+    }, 30_000);
+    silenceWatchdog.unref?.();
+
+    let sessionId: string | undefined;
+
+    try {
+      let first = true;
+      for await (const p of args.prompt) {
+        const text = typeof p === 'string' ? p : (p?.message?.content ?? String(p ?? ''));
+        let nextMessage = first ? `${args.systemPrompt}${buildToolProtocol(args.tools)}\n\n---\n\n${text}` : text;
+        first = false;
+
+        let turnInputTokens = 0;
+        let turnOutputTokens = 0;
+        let round = 0;
+
+        turnInFlight = true;
+        try {
+        turnLoop: for (;;) {
+          send(nextMessage);
+
+          const collectedText: string[] = [];
+          let sawResult = false;
+          let resultError: string | undefined;
+
+          for (;;) {
+            const ev = await nextEvent();
+            disarmHang();
+            const kind = ev.type as string | undefined;
+
+            if (kind === '__closed__' || kind === '__error__' || kind === '__hang__') {
+              if (kind === '__error__') {
+                throw ev.error as Error;
+              }
+              const hangSuspected = kind === '__hang__';
+              throw new Error(
+                hangSuspected
+                  ? `QwenRpcAgentRunner: qwen produced no output within ${STARTUP_GRACE_MS / 1000}s and was killed. ` +
+                    'This usually means it is stuck on a prompt headless mode has no way to answer. Run `qwen` ' +
+                    `once manually in a real terminal in this project to check, then retry.${stderrTail ? `\nstderr: ${stderrTail.slice(-500)}` : ''}`
+                  : `QwenRpcAgentRunner: qwen rpc process ended unexpectedly (${kind})` +
+                    (stderrTail ? `\nstderr: ${stderrTail.slice(-500)}` : ''),
+              );
+            }
+
+            const evSessionId = ev.session_id as string | undefined;
+            if (evSessionId) sessionId = evSessionId;
+
+            if (kind === 'assistant') {
+              const message = ev.message as QwenRpcMessage | undefined;
+              if (message) {
+                const t = extractQwenRpcText(message);
+                if (t) collectedText.push(t);
+              }
+              continue;
+            }
+
+            if (kind === 'result') {
+              sawResult = true;
+              const usage = ev.usage as { input_tokens?: number; output_tokens?: number } | undefined;
+              if (usage) {
+                turnInputTokens += usage.input_tokens ?? 0;
+                turnOutputTokens += usage.output_tokens ?? 0;
+              }
+              if (ev.subtype === 'error') {
+                const err = ev.error as { message?: string } | string | undefined;
+                resultError = typeof err === 'string' ? err : err?.message ?? 'qwen result: error';
+              }
+              break;
+            }
+
+            // system/init and anything else — drained and ignored.
+          }
+
+          if (resultError) {
+            throw new Error(`QwenRpcAgentRunner: qwen turn failed: ${resultError}` + (stderrTail ? `\nstderr: ${stderrTail.slice(-500)}` : ''));
+          }
+          if (!sawResult) break turnLoop; // process closed before result — nothing to extract this round
+
+          const rawText = collectedText.join('\n');
+          const visibleText = rawText.replace(TOOL_CALL_RE, '').trim();
+          if (visibleText) yield { type: 'assistant', session_id: sessionId, text: visibleText };
+
+          const malformed: string[] = [];
+          const calls = parseToolCalls([rawText], (raw, err) => malformed.push(
+            `[monomind] ignored malformed tool_call fence (${err}): ${raw.slice(0, 200)}`,
+          ));
+          for (const note of malformed) yield { type: 'assistant', session_id: sessionId, text: note };
+          if (calls.length === 0) break turnLoop;
+
+          round += 1;
+          if (round > MAX_TOOL_ROUNDS) {
+            yield { type: 'assistant', session_id: sessionId, text: `[monomind] tool-call round cap (${MAX_TOOL_ROUNDS}) reached — dropping ${calls.length} pending tool call(s)` };
+            break turnLoop;
+          }
+
+          toolCallInFlight = true;
+          const results: string[] = [];
+          try {
+            for (const call of calls) results.push(await executeToolCall(args.tools, call, args.canUseTool));
+          } finally {
+            toolCallInFlight = false;
+            lastEventAt = Date.now();
+          }
+          nextMessage = formatToolResults(calls, results);
+        }
+        } finally {
+          turnInFlight = false;
+        }
+
+        yield {
+          type: 'result',
+          session_id: sessionId,
+          subtype: 'success',
+          input_tokens: turnInputTokens,
+          output_tokens: turnOutputTokens,
+        };
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error(
+          'QwenRpcAgentRunner requires the Qwen Code CLI (qwen) on PATH. ' +
+          'Install it: npm install -g @qwen-code/qwen-code, then run `qwen` once ' +
+          'to authenticate. Or unset the runtime to use Claude.',
+        );
+      }
+      throw err;
+    } finally {
+      if (hangTimer) clearTimeout(hangTimer);
+      clearInterval(silenceWatchdog);
+      if (processExited) {
+        if (killTimer) clearTimeout(killTimer);
+      } else {
+        if (!killTimer) killChild();
+      }
+    }
+  }
+}

--- a/packages/@monomind/cli/src/orgrt/qwen-runner.ts
+++ b/packages/@monomind/cli/src/orgrt/qwen-runner.ts
@@ -12,14 +12,18 @@
  * Org tools — FENCE PROTOCOL: same approach as the other subprocess runners
  * (see tool-fence.ts).
  *
- * Subprocess protocol — per Qwen Code's public "Headless Mode" docs, NOT
- * byte-verified against a running binary:
+ * Subprocess protocol — LIVE-VERIFIED against qwen-code v0.21.13 (issue
+ * #182 investigation; z.ai/GLM-5.3 as the OpenAI-compatible backend, `qwen
+ * --auth-type openai` + `OPENAI_API_KEY`/`OPENAI_BASE_URL`/`OPENAI_MODEL`):
  *   - Invocation: `qwen -p "<prompt>" --output-format stream-json --yolo
  *                 [-m <model>] [--resume <sessionId> | --continue]`
- *   - stream-json emits one JSON object per line; documented shape:
+ *   - stream-json emits one JSON object per line; CONFIRMED shape (the
+ *     public docs' `usage.tokens.{input,output}` nesting does NOT match
+ *     live output — real usage fields are flat):
  *       { type: 'system'|'assistant'|'result', subtype, uuid, session_id,
  *         role: 'assistant',
- *         message: { content: [{type:'text', text}], usage: { tokens: { input, output, total } } } }
+ *         message: { content: [{type:'text', text}],
+ *                     usage: { input_tokens, output_tokens, cache_read_input_tokens, total_tokens } } }
  *   - Session continuity: `--resume [sessionId]` resumes a specific session,
  *     `--continue` resumes the most recent one; `session_id` is carried on
  *     every event.
@@ -39,7 +43,6 @@ const STARTUP_GRACE_MS = 45_000;
 
 interface QwenMessage {
   content?: Array<{ type: string; text?: string }>;
-  usage?: { tokens?: { input?: number; output?: number } };
 }
 
 interface QwenEvent {
@@ -47,6 +50,11 @@ interface QwenEvent {
   subtype?: string;
   session_id?: string;
   message?: QwenMessage;
+  /** Confirmed live (issue #182): on `result` events, usage is TOP-LEVEL
+   *  and flat, NOT nested under `message.usage.tokens` as the public docs
+   *  suggest. `assistant` events don't carry a top-level `usage` at all in
+   *  observed output. */
+  usage?: { input_tokens?: number; output_tokens?: number };
   error?: { message?: string } | string;
 }
 
@@ -93,10 +101,9 @@ export function parseQwenEvents(lines: string[]): {
     }
 
     if (ev.type === 'result') {
-      const tokens = ev.message?.usage?.tokens;
-      if (tokens) {
-        inputTokens = tokens.input ?? 0;
-        outputTokens = tokens.output ?? 0;
+      if (ev.usage) {
+        inputTokens = ev.usage.input_tokens ?? 0;
+        outputTokens = ev.usage.output_tokens ?? 0;
       }
       if (ev.subtype === 'error') {
         error = typeof ev.error === 'string' ? ev.error : ev.error?.message ?? 'qwen result: error';

--- a/packages/@monomind/cli/src/orgrt/types.ts
+++ b/packages/@monomind/cli/src/orgrt/types.ts
@@ -122,7 +122,7 @@ export const RoleSchema = z.object({
    *  agent runtime regardless of the org-level `runtime` field or the
    *  MONOMIND_RUNTIME env var ('claude' explicitly forces the Claude default).
    *  Enables mixed-runtime orgs — e.g. a Claude coordinator with opencode workers. */
-  runtime: z.enum(['claude', 'kimicode', 'opencode', 'vercel', 'codex', 'antigravity', 'grok', 'qwen', 'crush', 'copilot', 'pi', 'pi-rpc']).optional(),
+  runtime: z.enum(['claude', 'kimicode', 'opencode', 'vercel', 'codex', 'antigravity', 'grok', 'qwen', 'crush', 'copilot', 'pi', 'pi-rpc', 'qwen-rpc']).optional(),
   /** Per-role override of run_config.max_turns_per_message — roles that legitimately
    *  need many more turns per message (e.g. a developer doing sequential build/fix/verify
    *  cycles) than others (e.g. docs, pm) shouldn't be forced onto one global budget. */
@@ -183,7 +183,7 @@ export const OrgDefSchema = z.object({
    *  MONOMIND_RUNTIME env var is honored, falling back to the default Claude
    *  runner. Per-org values override the env var, and a role's own `runtime`
    *  field (see RoleSchema) overrides this per role. */
-  runtime: z.enum(['claude', 'kimicode', 'opencode', 'vercel', 'codex', 'antigravity', 'grok', 'qwen', 'crush', 'copilot', 'pi', 'pi-rpc']).optional(),
+  runtime: z.enum(['claude', 'kimicode', 'opencode', 'vercel', 'codex', 'antigravity', 'grok', 'qwen', 'crush', 'copilot', 'pi', 'pi-rpc', 'qwen-rpc']).optional(),
 }).passthrough();
 
 export type OrgDef = z.infer<typeof OrgDefSchema>;


### PR DESCRIPTION
## Summary
Live-verified against qwen-code v0.21.13 with a z.ai/GLM-5.3 backend:
- New opt-in `runtime: 'qwen-rpc'` (`QwenRpcAgentRunner`) mirroring `pi-rpc-runner.ts` — persistent subprocess for the whole mailbox session via `--input-format/--output-format stream-json`. Client→server schema found by reading qwen-code's own bundled source, then live-confirmed (two messages on one subprocess, same session_id, both answered correctly).
- Full multi-turn smoke test through the actual runner: secret-word recall across turns (proves session persistence) + an `org_send` tool-call fence round-trip, correctly-summed non-zero token usage.
- **Bonus real bug fixed**: the existing non-RPC `qwen-runner.ts` assumed `usage` was nested under `message.usage.tokens.{input,output}` — live output shows it's flat (`usage.input_tokens`/`usage.output_tokens`) on both `assistant` and `result` events. This was silently reporting 0 tokens for every qwen-backed turn in production.
- Wired `'qwen-rpc'` into `daemon.ts`'s `RuntimeKind`/`resolveRunner` and `types.ts`'s runtime enum.

## Test plan
- [x] `vitest run __tests__/orgrt/qwen-rpc-runner.test.ts __tests__/orgrt/qwen-runner.test.ts` — 21/21 passing
- [x] `tsc --noEmit` (full package) — no errors
- [x] Live end-to-end smoke test through `QwenRpcAgentRunner.run()`: multi-turn session persistence + org tool-call fence round-trip against z.ai/GLM-5.3
- [x] Live end-to-end smoke test through `QwenAgentRunner.run()` confirming the usage-field fix reports real non-zero tokens