### PR TITLE
fix(orgrt): scope hasActiveBlock to the whole DAG, not any single task

### DIFF
--- a/packages/@monomind/cli/src/__tests__/task-dag-block.test.ts
+++ b/packages/@monomind/cli/src/__tests__/task-dag-block.test.ts
@@ -66,6 +66,34 @@ describe('TaskDag — block/unblockExpired/hasActiveBlock', () => {
     expect(dag.hasActiveBlock(Date.now())).toBe(false);
   });
 
+  it('hasActiveBlock is false when one task is blocked far in the future but another is still running', () => {
+    // Regression: a single long-lived block (e.g. a feature deferred for
+    // weeks) must not silence the idle watchdog for the whole org while
+    // unrelated work is genuinely outstanding.
+    const dag = new TaskDag();
+    const deferred = dag.add('deferred feature', 'a');
+    dag.markRunning(deferred.id);
+    dag.block(deferred.id, Date.now() + 14 * 24 * 60 * 60 * 1000, 'deferred for weeks');
+
+    const active = dag.add('unrelated in-progress work', 'b');
+    dag.markRunning(active.id);
+
+    expect(dag.hasActiveBlock(Date.now())).toBe(false);
+  });
+
+  it('hasActiveBlock is true when every non-terminal task is blocked on a future time', () => {
+    const dag = new TaskDag();
+    const t1 = dag.add('x', 'a');
+    dag.markRunning(t1.id);
+    dag.block(t1.id, Date.now() + 60_000);
+
+    const t2 = dag.add('y', 'b');
+    dag.markRunning(t2.id);
+    dag.block(t2.id, Date.now() + 90_000);
+
+    expect(dag.hasActiveBlock(Date.now())).toBe(true);
+  });
+
   it('unblockExpired transitions an expired block back to running and clears blockedUntil/reason', () => {
     const dag = new TaskDag();
     const t = dag.add('x', 'a');

--- a/packages/@monomind/cli/src/orgrt/task-dag.ts
+++ b/packages/@monomind/cli/src/orgrt/task-dag.ts
@@ -110,13 +110,26 @@ export class TaskDag {
     return unblocked;
   }
 
-  /** True if any task is blocked on a real-world time still in the future —
-   *  the watchdog's signal to skip nudging (same treatment as a pending gate). */
+  /** True if there is genuinely nothing else dispatchable right now — every
+   *  non-terminal task is blocked on a real-world time still in the future.
+   *  This is the watchdog's signal to skip nudging (same treatment as a
+   *  pending gate). Scoped to the whole DAG rather than a single task on
+   *  purpose: if ANY task is pending/ready/running, or blocked with a time
+   *  that's already passed (should have auto-resumed), there is real
+   *  outstanding work and nudging is still meaningful — a single long-lived
+   *  block on one task (e.g. a feature deferred for weeks) must not silence
+   *  the watchdog for the entire org while other roles sit genuinely idle. */
   hasActiveBlock(now: number): boolean {
+    let sawBlocked = false;
     for (const t of this.tasks.values()) {
-      if (t.status === 'blocked' && (t.blockedUntil ?? 0) > now) return true;
+      if (TERMINAL.has(t.status)) continue;
+      if (t.status === 'blocked' && (t.blockedUntil ?? 0) > now) {
+        sawBlocked = true;
+        continue;
+      }
+      return false;
     }
-    return false;
+    return sawBlocked;
   }
 
   split(parentId: string, children: SplitChild[]): OrgTask[] {


### PR DESCRIPTION
## Summary
- `TaskDag.hasActiveBlock()` returned `true` whenever **any single task** had a future `blockedUntil`, and the idle watchdog treats a `true` result as "skip nudging this tick" for the **entire org** (`daemon.ts`: `if (running.taskDag?.hasActiveBlock(Date.now())) return;`).
- Since the watchdog is one per-org timer, a single long-lived `org_task_block` on an unrelated task (e.g. a feature deferred weeks out) silently disabled idle-nudge *and* idle-stop protection for every role — even while other tasks sat genuinely idle for tens of minutes with zero bus activity.
- Observed live on a 50+ hour running org: after one task was blocked ~2 weeks out, the watchdog's automatic 10-minute nudge (previously firing reliably many times earlier in the same run) never fired again, despite multiple later ~30-40 minute silent gaps where other roles were stalled waiting on external CI with nothing happening.
- Fix: `hasActiveBlock` now returns `true` only when **every non-terminal task** is blocked on a future time — i.e. there's genuinely nothing else dispatchable. Any `pending`/`ready`/`running` task, or a `blocked` task whose time has already passed, means real outstanding work exists and nudging is still meaningful.

Fixes #194

## Test plan
- [x] Added a regression test: one task blocked 14 days out + another task still `running` → `hasActiveBlock` is `false` (previously would have been `true`, silencing the watchdog org-wide).
- [x] Added a companion test: every non-terminal task blocked → `hasActiveBlock` is `true` (still-correct original behavior for the fully-blocked case).
- [x] Existing `task-dag-block.test.ts` suite passes (17/18 tests pass; the 1 pre-existing failure in `dag-block-task.test.ts` is unrelated and reproduces identically on `origin/main` before this change).
- [x] `tsc --noEmit` shows no new errors (pre-existing unrelated `@monoes/monograph` export errors only, reproduce on `origin/main`).