### PR TITLE
fix(windows): pair dashboard-token without lsof (broken cross-project pairing on Windows)

### DIFF
--- a/.claude/helpers/control-start.cjs
+++ b/.claude/helpers/control-start.cjs
@@ -154,6 +154,42 @@ function probePort(p) {
   });
 }
 
+// Resolves a foreign dashboard server's real pid + project directory without
+// shelling out to `lsof` (Unix-only — unavailable on Windows, which left the
+// pairing step below permanently broken there: control.json stuck at pid:0
+// forever, dashboard-token never refreshed after the shared server restarts).
+// GET / is an intentionally-open route that embeds the live auth token in a
+// <meta name="mm-token"> tag for exactly this same-machine, loopback-trusted
+// purpose; re-using it here to authenticate a follow-up GET /api/status call
+// gets both the pid and the project `dir` in one portable HTTP round trip —
+// no OS-specific process inspection needed on any platform.
+function fetchForeignServerInfo(p) {
+  const http = require('http');
+  const getBody = (reqPath, headers) => new Promise((resolve) => {
+    const req = http.get({ hostname: 'localhost', port: p, path: reqPath, timeout: 1500, headers }, (res) => {
+      let body = '';
+      res.on('data', (c) => { if (body.length < 65536) body += c; });
+      res.on('end', () => resolve({ statusCode: res.statusCode, body }));
+    });
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => { req.destroy(); resolve(null); });
+  });
+  return (async () => {
+    const home = await getBody('/');
+    if (!home) return null;
+    const m = home.body.match(/name="mm-token" content="([^"]*)"/);
+    const token = m ? m[1] : null;
+    if (!token) return null;
+    const status = await getBody('/api/status', { 'x-monomind-token': token });
+    if (!status) return null;
+    try {
+      const parsed = JSON.parse(status.body);
+      if (typeof parsed.pid !== 'number' || typeof parsed.dir !== 'string') return null;
+      return { pid: parsed.pid, dir: parsed.dir, token };
+    } catch { return null; }
+  })();
+}
+
 const LOCK_FILE = path.join(CWD, '.monomind', 'control.lock');
 
 /**
@@ -252,8 +288,14 @@ async function runConfirm({ childPid, port: defaultPort, boundReportPath, isNpxF
     // and kill our redundant child.
     try { process.kill(childPid, 'SIGTERM'); } catch { /* already gone */ }
     if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] port ${defaultPort} is served by another project's control server — reusing it (killed redundant child)\n`);
-    let foreignPid = await probePort(defaultPort);
+    // Primary: authenticate via the foreign server's own open "/" route (see
+    // fetchForeignServerInfo doc comment) to get its real pid + project dir
+    // in one portable HTTP round trip — works on every platform, no `lsof`.
+    const foreignInfo = await fetchForeignServerInfo(defaultPort);
+    let foreignPid = foreignInfo ? foreignInfo.pid : await probePort(defaultPort);
     if (typeof foreignPid !== 'number' || foreignPid <= 0) {
+      // Last-resort fallback for exotic setups where the HTTP path above
+      // failed (e.g. a pre-token-route legacy server) — Unix-only.
       try {
         const { execFileSync } = require('child_process');
         const lsofOut = execFileSync('lsof', ['-ti', `:${defaultPort}`, '-sTCP:LISTEN'], { encoding: 'utf8', timeout: 3000 }).trim();
@@ -262,34 +304,50 @@ async function runConfirm({ childPid, port: defaultPort, boundReportPath, isNpxF
       } catch { /* ignore */ }
     }
     writeStatus(typeof foreignPid === 'number' ? foreignPid : 0, defaultPort);
-    // Pair with the foreign server: resolve its project dir from its pid,
-    // copy its dashboard-token beside OUR control.json (ingest is
-    // default-deny — without this every event from this project 401s
-    // silently), and self-register in its known-projects so future token
-    // rotations propagate back here on server restart.
+    // Pair with the foreign server: copy its dashboard-token beside OUR
+    // control.json (ingest is default-deny — without this every event from
+    // this project 401s silently), and self-register in its known-projects
+    // so future token rotations propagate back here on server restart.
     try {
-      if (typeof foreignPid === 'number' && foreignPid > 0) {
-        const { execFileSync } = require('child_process');
-        const out = execFileSync('lsof', ['-a', '-p', String(foreignPid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', timeout: 3000 });
-        const nLine = out.split('\n').find((l) => l.startsWith('n'));
-        const serverHome = nLine ? nLine.slice(1) : null;
-        if (serverHome) {
-          const srcTok = path.join(serverHome, '.monomind', 'dashboard-token');
-          const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
-          if (fs.existsSync(srcTok)) {
-            fs.copyFileSync(srcTok, dstTok);
-            fs.chmodSync(dstTok, 0o600);
+      if (foreignInfo) {
+        const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
+        fs.mkdirSync(path.dirname(dstTok), { recursive: true });
+        fs.writeFileSync(dstTok, foreignInfo.token, { mode: 0o600 });
+        const kpFile = path.join(foreignInfo.dir, 'data', 'known-projects.json');
+        try {
+          const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
+          if (Array.isArray(kp) && !kp.includes(CWD)) {
+            kp.push(CWD);
+            fs.writeFileSync(kpFile, JSON.stringify(kp));
           }
-          const kpFile = path.join(serverHome, 'data', 'known-projects.json');
-          try {
-            const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
-            if (Array.isArray(kp) && !kp.includes(CWD)) {
-              kp.push(CWD);
-              fs.writeFileSync(kpFile, JSON.stringify(kp));
+        } catch { /* registry unreadable — token copy alone still unblocks events */ }
+        process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
+      } else if (typeof foreignPid === 'number' && foreignPid > 0) {
+        // lsof gave us a pid but not a dir (it only resolves TCP listeners,
+        // not cwd) — fall back to its cwd resolution for the dir we need.
+        try {
+          const { execFileSync } = require('child_process');
+          const out = execFileSync('lsof', ['-a', '-p', String(foreignPid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', timeout: 3000 });
+          const nLine = out.split('\n').find((l) => l.startsWith('n'));
+          const serverHome = nLine ? nLine.slice(1) : null;
+          if (serverHome) {
+            const srcTok = path.join(serverHome, '.monomind', 'dashboard-token');
+            const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
+            if (fs.existsSync(srcTok)) {
+              fs.copyFileSync(srcTok, dstTok);
+              fs.chmodSync(dstTok, 0o600);
             }
-          } catch { /* registry unreadable — token copy alone still unblocks events */ }
-          process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
-        }
+            const kpFile = path.join(serverHome, 'data', 'known-projects.json');
+            try {
+              const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
+              if (Array.isArray(kp) && !kp.includes(CWD)) {
+                kp.push(CWD);
+                fs.writeFileSync(kpFile, JSON.stringify(kp));
+              }
+            } catch { /* registry unreadable — token copy alone still unblocks events */ }
+            process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
+          }
+        } catch { /* pairing is best-effort; propagation-on-restart is the fallback */ }
       }
     } catch { /* pairing is best-effort; propagation-on-restart is the fallback */ }
     return;

--- a/.gemini/helpers/control-start.cjs
+++ b/.gemini/helpers/control-start.cjs
@@ -154,6 +154,42 @@ function probePort(p) {
   });
 }
 
+// Resolves a foreign dashboard server's real pid + project directory without
+// shelling out to `lsof` (Unix-only — unavailable on Windows, which left the
+// pairing step below permanently broken there: control.json stuck at pid:0
+// forever, dashboard-token never refreshed after the shared server restarts).
+// GET / is an intentionally-open route that embeds the live auth token in a
+// <meta name="mm-token"> tag for exactly this same-machine, loopback-trusted
+// purpose; re-using it here to authenticate a follow-up GET /api/status call
+// gets both the pid and the project `dir` in one portable HTTP round trip —
+// no OS-specific process inspection needed on any platform.
+function fetchForeignServerInfo(p) {
+  const http = require('http');
+  const getBody = (reqPath, headers) => new Promise((resolve) => {
+    const req = http.get({ hostname: 'localhost', port: p, path: reqPath, timeout: 1500, headers }, (res) => {
+      let body = '';
+      res.on('data', (c) => { if (body.length < 65536) body += c; });
+      res.on('end', () => resolve({ statusCode: res.statusCode, body }));
+    });
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => { req.destroy(); resolve(null); });
+  });
+  return (async () => {
+    const home = await getBody('/');
+    if (!home) return null;
+    const m = home.body.match(/name="mm-token" content="([^"]*)"/);
+    const token = m ? m[1] : null;
+    if (!token) return null;
+    const status = await getBody('/api/status', { 'x-monomind-token': token });
+    if (!status) return null;
+    try {
+      const parsed = JSON.parse(status.body);
+      if (typeof parsed.pid !== 'number' || typeof parsed.dir !== 'string') return null;
+      return { pid: parsed.pid, dir: parsed.dir, token };
+    } catch { return null; }
+  })();
+}
+
 const LOCK_FILE = path.join(CWD, '.monomind', 'control.lock');
 
 /**
@@ -252,8 +288,14 @@ async function runConfirm({ childPid, port: defaultPort, boundReportPath, isNpxF
     // and kill our redundant child.
     try { process.kill(childPid, 'SIGTERM'); } catch { /* already gone */ }
     if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] port ${defaultPort} is served by another project's control server — reusing it (killed redundant child)\n`);
-    let foreignPid = await probePort(defaultPort);
+    // Primary: authenticate via the foreign server's own open "/" route (see
+    // fetchForeignServerInfo doc comment) to get its real pid + project dir
+    // in one portable HTTP round trip — works on every platform, no `lsof`.
+    const foreignInfo = await fetchForeignServerInfo(defaultPort);
+    let foreignPid = foreignInfo ? foreignInfo.pid : await probePort(defaultPort);
     if (typeof foreignPid !== 'number' || foreignPid <= 0) {
+      // Last-resort fallback for exotic setups where the HTTP path above
+      // failed (e.g. a pre-token-route legacy server) — Unix-only.
       try {
         const { execFileSync } = require('child_process');
         const lsofOut = execFileSync('lsof', ['-ti', `:${defaultPort}`, '-sTCP:LISTEN'], { encoding: 'utf8', timeout: 3000 }).trim();
@@ -262,34 +304,50 @@ async function runConfirm({ childPid, port: defaultPort, boundReportPath, isNpxF
       } catch { /* ignore */ }
     }
     writeStatus(typeof foreignPid === 'number' ? foreignPid : 0, defaultPort);
-    // Pair with the foreign server: resolve its project dir from its pid,
-    // copy its dashboard-token beside OUR control.json (ingest is
-    // default-deny — without this every event from this project 401s
-    // silently), and self-register in its known-projects so future token
-    // rotations propagate back here on server restart.
+    // Pair with the foreign server: copy its dashboard-token beside OUR
+    // control.json (ingest is default-deny — without this every event from
+    // this project 401s silently), and self-register in its known-projects
+    // so future token rotations propagate back here on server restart.
     try {
-      if (typeof foreignPid === 'number' && foreignPid > 0) {
-        const { execFileSync } = require('child_process');
-        const out = execFileSync('lsof', ['-a', '-p', String(foreignPid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', timeout: 3000 });
-        const nLine = out.split('\n').find((l) => l.startsWith('n'));
-        const serverHome = nLine ? nLine.slice(1) : null;
-        if (serverHome) {
-          const srcTok = path.join(serverHome, '.monomind', 'dashboard-token');
-          const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
-          if (fs.existsSync(srcTok)) {
-            fs.copyFileSync(srcTok, dstTok);
-            fs.chmodSync(dstTok, 0o600);
+      if (foreignInfo) {
+        const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
+        fs.mkdirSync(path.dirname(dstTok), { recursive: true });
+        fs.writeFileSync(dstTok, foreignInfo.token, { mode: 0o600 });
+        const kpFile = path.join(foreignInfo.dir, 'data', 'known-projects.json');
+        try {
+          const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
+          if (Array.isArray(kp) && !kp.includes(CWD)) {
+            kp.push(CWD);
+            fs.writeFileSync(kpFile, JSON.stringify(kp));
           }
-          const kpFile = path.join(serverHome, 'data', 'known-projects.json');
-          try {
-            const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
-            if (Array.isArray(kp) && !kp.includes(CWD)) {
-              kp.push(CWD);
-              fs.writeFileSync(kpFile, JSON.stringify(kp));
+        } catch { /* registry unreadable — token copy alone still unblocks events */ }
+        process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
+      } else if (typeof foreignPid === 'number' && foreignPid > 0) {
+        // lsof gave us a pid but not a dir (it only resolves TCP listeners,
+        // not cwd) — fall back to its cwd resolution for the dir we need.
+        try {
+          const { execFileSync } = require('child_process');
+          const out = execFileSync('lsof', ['-a', '-p', String(foreignPid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', timeout: 3000 });
+          const nLine = out.split('\n').find((l) => l.startsWith('n'));
+          const serverHome = nLine ? nLine.slice(1) : null;
+          if (serverHome) {
+            const srcTok = path.join(serverHome, '.monomind', 'dashboard-token');
+            const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
+            if (fs.existsSync(srcTok)) {
+              fs.copyFileSync(srcTok, dstTok);
+              fs.chmodSync(dstTok, 0o600);
             }
-          } catch { /* registry unreadable — token copy alone still unblocks events */ }
-          process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
-        }
+            const kpFile = path.join(serverHome, 'data', 'known-projects.json');
+            try {
+              const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
+              if (Array.isArray(kp) && !kp.includes(CWD)) {
+                kp.push(CWD);
+                fs.writeFileSync(kpFile, JSON.stringify(kp));
+              }
+            } catch { /* registry unreadable — token copy alone still unblocks events */ }
+            process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
+          }
+        } catch { /* pairing is best-effort; propagation-on-restart is the fallback */ }
       }
     } catch { /* pairing is best-effort; propagation-on-restart is the fallback */ }
     return;

--- a/packages/@monomind/cli/.claude/helpers/control-start.cjs
+++ b/packages/@monomind/cli/.claude/helpers/control-start.cjs
@@ -154,6 +154,42 @@ function probePort(p) {
   });
 }
 
+// Resolves a foreign dashboard server's real pid + project directory without
+// shelling out to `lsof` (Unix-only — unavailable on Windows, which left the
+// pairing step below permanently broken there: control.json stuck at pid:0
+// forever, dashboard-token never refreshed after the shared server restarts).
+// GET / is an intentionally-open route that embeds the live auth token in a
+// <meta name="mm-token"> tag for exactly this same-machine, loopback-trusted
+// purpose; re-using it here to authenticate a follow-up GET /api/status call
+// gets both the pid and the project `dir` in one portable HTTP round trip —
+// no OS-specific process inspection needed on any platform.
+function fetchForeignServerInfo(p) {
+  const http = require('http');
+  const getBody = (reqPath, headers) => new Promise((resolve) => {
+    const req = http.get({ hostname: 'localhost', port: p, path: reqPath, timeout: 1500, headers }, (res) => {
+      let body = '';
+      res.on('data', (c) => { if (body.length < 65536) body += c; });
+      res.on('end', () => resolve({ statusCode: res.statusCode, body }));
+    });
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => { req.destroy(); resolve(null); });
+  });
+  return (async () => {
+    const home = await getBody('/');
+    if (!home) return null;
+    const m = home.body.match(/name="mm-token" content="([^"]*)"/);
+    const token = m ? m[1] : null;
+    if (!token) return null;
+    const status = await getBody('/api/status', { 'x-monomind-token': token });
+    if (!status) return null;
+    try {
+      const parsed = JSON.parse(status.body);
+      if (typeof parsed.pid !== 'number' || typeof parsed.dir !== 'string') return null;
+      return { pid: parsed.pid, dir: parsed.dir, token };
+    } catch { return null; }
+  })();
+}
+
 const LOCK_FILE = path.join(CWD, '.monomind', 'control.lock');
 
 /**
@@ -252,8 +288,14 @@ async function runConfirm({ childPid, port: defaultPort, boundReportPath, isNpxF
     // and kill our redundant child.
     try { process.kill(childPid, 'SIGTERM'); } catch { /* already gone */ }
     if (String(process.env.MONOMIND_HOOK_QUIET || "") !== "1") process.stdout.write(`[control] port ${defaultPort} is served by another project's control server — reusing it (killed redundant child)\n`);
-    let foreignPid = await probePort(defaultPort);
+    // Primary: authenticate via the foreign server's own open "/" route (see
+    // fetchForeignServerInfo doc comment) to get its real pid + project dir
+    // in one portable HTTP round trip — works on every platform, no `lsof`.
+    const foreignInfo = await fetchForeignServerInfo(defaultPort);
+    let foreignPid = foreignInfo ? foreignInfo.pid : await probePort(defaultPort);
     if (typeof foreignPid !== 'number' || foreignPid <= 0) {
+      // Last-resort fallback for exotic setups where the HTTP path above
+      // failed (e.g. a pre-token-route legacy server) — Unix-only.
       try {
         const { execFileSync } = require('child_process');
         const lsofOut = execFileSync('lsof', ['-ti', `:${defaultPort}`, '-sTCP:LISTEN'], { encoding: 'utf8', timeout: 3000 }).trim();
@@ -262,34 +304,50 @@ async function runConfirm({ childPid, port: defaultPort, boundReportPath, isNpxF
       } catch { /* ignore */ }
     }
     writeStatus(typeof foreignPid === 'number' ? foreignPid : 0, defaultPort);
-    // Pair with the foreign server: resolve its project dir from its pid,
-    // copy its dashboard-token beside OUR control.json (ingest is
-    // default-deny — without this every event from this project 401s
-    // silently), and self-register in its known-projects so future token
-    // rotations propagate back here on server restart.
+    // Pair with the foreign server: copy its dashboard-token beside OUR
+    // control.json (ingest is default-deny — without this every event from
+    // this project 401s silently), and self-register in its known-projects
+    // so future token rotations propagate back here on server restart.
     try {
-      if (typeof foreignPid === 'number' && foreignPid > 0) {
-        const { execFileSync } = require('child_process');
-        const out = execFileSync('lsof', ['-a', '-p', String(foreignPid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', timeout: 3000 });
-        const nLine = out.split('\n').find((l) => l.startsWith('n'));
-        const serverHome = nLine ? nLine.slice(1) : null;
-        if (serverHome) {
-          const srcTok = path.join(serverHome, '.monomind', 'dashboard-token');
-          const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
-          if (fs.existsSync(srcTok)) {
-            fs.copyFileSync(srcTok, dstTok);
-            fs.chmodSync(dstTok, 0o600);
+      if (foreignInfo) {
+        const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
+        fs.mkdirSync(path.dirname(dstTok), { recursive: true });
+        fs.writeFileSync(dstTok, foreignInfo.token, { mode: 0o600 });
+        const kpFile = path.join(foreignInfo.dir, 'data', 'known-projects.json');
+        try {
+          const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
+          if (Array.isArray(kp) && !kp.includes(CWD)) {
+            kp.push(CWD);
+            fs.writeFileSync(kpFile, JSON.stringify(kp));
           }
-          const kpFile = path.join(serverHome, 'data', 'known-projects.json');
-          try {
-            const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
-            if (Array.isArray(kp) && !kp.includes(CWD)) {
-              kp.push(CWD);
-              fs.writeFileSync(kpFile, JSON.stringify(kp));
+        } catch { /* registry unreadable — token copy alone still unblocks events */ }
+        process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
+      } else if (typeof foreignPid === 'number' && foreignPid > 0) {
+        // lsof gave us a pid but not a dir (it only resolves TCP listeners,
+        // not cwd) — fall back to its cwd resolution for the dir we need.
+        try {
+          const { execFileSync } = require('child_process');
+          const out = execFileSync('lsof', ['-a', '-p', String(foreignPid), '-d', 'cwd', '-Fn'], { encoding: 'utf8', timeout: 3000 });
+          const nLine = out.split('\n').find((l) => l.startsWith('n'));
+          const serverHome = nLine ? nLine.slice(1) : null;
+          if (serverHome) {
+            const srcTok = path.join(serverHome, '.monomind', 'dashboard-token');
+            const dstTok = path.join(CWD, '.monomind', 'dashboard-token');
+            if (fs.existsSync(srcTok)) {
+              fs.copyFileSync(srcTok, dstTok);
+              fs.chmodSync(dstTok, 0o600);
             }
-          } catch { /* registry unreadable — token copy alone still unblocks events */ }
-          process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
-        }
+            const kpFile = path.join(serverHome, 'data', 'known-projects.json');
+            try {
+              const kp = fs.existsSync(kpFile) ? JSON.parse(fs.readFileSync(kpFile, 'utf8')) : [];
+              if (Array.isArray(kp) && !kp.includes(CWD)) {
+                kp.push(CWD);
+                fs.writeFileSync(kpFile, JSON.stringify(kp));
+              }
+            } catch { /* registry unreadable — token copy alone still unblocks events */ }
+            process.stdout.write('[control] paired dashboard token and registered this project with the shared server\n');
+          }
+        } catch { /* pairing is best-effort; propagation-on-restart is the fallback */ }
       }
     } catch { /* pairing is best-effort; propagation-on-restart is the fallback */ }
     return;

--- a/tests/hooks/control-start.test.mjs
+++ b/tests/hooks/control-start.test.mjs
@@ -289,6 +289,91 @@ describe('control-start: confirmPort waits on liveness, not a fixed budget (#142
   });
 });
 
+describe('control-start: foreign-server pairing works without lsof (Windows regression)', () => {
+  // Regression: the "adopt a foreign project's dashboard server" pairing step
+  // (dashboard-token copy + known-projects.json self-registration) used to
+  // resolve the foreign server's pid/project-dir by shelling out to `lsof`
+  // (`lsof -ti :<port> -sTCP:LISTEN` then `lsof -a -p <pid> -d cwd -Fn`).
+  // `lsof` doesn't exist on Windows, so on Windows this pairing NEVER
+  // succeeded — control.json stayed stuck at pid:0 forever and
+  // dashboard-token was never refreshed after the shared server restarted,
+  // silently 401ing every subsequent event/hook call from the adopting
+  // project. fetchForeignServerInfo() replaces both lsof calls with a
+  // portable HTTP round trip (GET / for the open mm-token, then an
+  // authenticated GET /api/status for pid+dir) that works on every platform.
+  it('pairs dashboard-token and known-projects.json via HTTP only, using a dead childPid to force the foreign-server path', async () => {
+    const { spawn } = await import('child_process');
+    const port = isolatedPort();
+    const mockAuth = 'fixture-' + 'pairing-test-value';
+    const serverHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cs-serverhome-'));
+    // Real server homes always have a data/ dir (packaged with the CLI) —
+    // pre-create it so this test doesn't hit an unrelated missing-dir ENOENT.
+    fs.mkdirSync(path.join(serverHomeDir, 'data'), { recursive: true });
+
+    const mockScript = path.join(tmpDir, 'mock-foreign-server.cjs');
+    fs.writeFileSync(mockScript, `
+      const http = require('http');
+      const AUTH_VALUE = ${JSON.stringify(mockAuth)};
+      const server = http.createServer((req, res) => {
+        const url = req.url.split('?')[0];
+        if (url === '/') {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<head>\\n<meta name="mm-token" content="' + AUTH_VALUE + '">\\n</head>');
+          return;
+        }
+        if (url === '/api/status') {
+          if (req.headers['x-monomind-token'] !== AUTH_VALUE) {
+            res.writeHead(401, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Unauthorized: missing or invalid auth token' }));
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ pid: process.pid, dir: ${JSON.stringify(serverHomeDir)} }));
+          return;
+        }
+        res.writeHead(404); res.end('Not found');
+      });
+      server.listen(${port}, 'localhost', () => process.stderr.write('READY'));
+    `);
+    const mock = spawn(process.execPath, [mockScript], { stdio: ['ignore', 'ignore', 'pipe'] });
+    await new Promise((resolve) => mock.stderr.on('data', resolve));
+
+    const boundReportPath = path.join(tmpDir, `.bound-report-${port}.json`);
+    try {
+      // childPid deliberately dead + not npx-fallback (CONFIRM_ATTEMPTS=20,
+      // 500ms/attempt) so runConfirm gives up on "is this our own child"
+      // after ~10s and falls into the sawForeignOnDefault pairing branch.
+      const r = spawnSync(process.execPath, [SCRIPT], {
+        cwd: tmpDir,
+        encoding: 'utf-8',
+        timeout: 35000,
+        env: {
+          ...process.env,
+          CLAUDE_PROJECT_DIR: tmpDir,
+          MONOMIND_HOOK_QUIET: '',
+          MONOMIND_CONTROL_CONFIRM_MODE: '1',
+          MONOMIND_CONTROL_CONFIRM_PID: '999999999',
+          MONOMIND_CONTROL_CONFIRM_PORT: String(port),
+          MONOMIND_CONTROL_CONFIRM_REPORT: boundReportPath,
+          MONOMIND_CONTROL_CONFIRM_NPX: '0',
+        },
+      });
+
+      expect(r.stdout).toContain('paired dashboard token and registered this project with the shared server');
+
+      const dstTok = path.join(tmpDir, '.monomind', 'dashboard-token');
+      expect(fs.readFileSync(dstTok, 'utf-8')).toBe(mockAuth);
+
+      const kpFile = path.join(serverHomeDir, 'data', 'known-projects.json');
+      const known = JSON.parse(fs.readFileSync(kpFile, 'utf-8'));
+      expect(known).toContain(tmpDir);
+    } finally {
+      mock.kill('SIGTERM');
+      fs.rmSync(serverHomeDir, { recursive: true, force: true });
+    }
+  }, 40000);
+});
+
 describe('control-start: confirmation runs detached from the hook-invoked process (#144)', () => {
   // The SessionStart hook that invokes this script has only a 5s timeout
   // (settings.json), far short of what confirmPort/runConfirm can


### PR DESCRIPTION
## Summary
- `runConfirm()`'s foreign-server pairing step in `.claude/helpers/control-start.cjs` (and its mirrors under `.gemini/helpers/` and `packages/@monomind/cli/.claude/helpers/`) resolved a foreign dashboard server's pid + project directory by shelling out to `lsof`, which does not exist on Windows.
- Both `lsof` calls silently fail there (swallowed by try/catch), so `control.json` stays stuck at `pid: 0` forever, `dashboard-token` never refreshes after the shared server restarts, and the project never gets added to that server's `data/known-projects.json`. Every subsequent authenticated call from the adopting project 401s silently — including the per-prompt Second Brain injection, which degrades to keyword fallback.
- `fetchForeignServerInfo()` replaces both `lsof` calls with a portable HTTP round trip: `GET /` (already an open route — embeds the live token in `<meta name="mm-token">` for exactly this same-machine, loopback-trusted purpose) to get the token, then an authenticated `GET /api/status` (which already returns `pid` and `dir`) to resolve both values in one call. No OS-specific process inspection needed on any platform. The old `lsof` path is kept only as a last-resort fallback for exotic setups.

Fixes #196.

## Root cause
`probePort()`'s unauthenticated `GET /api/status` always returns the sentinel `'foreign-authwalled'` against a real server (since `_checkAuth` in `server.mjs` default-denies every `/api/*` route), so the pairing block always fell through to the `lsof` fallback — which then simply doesn't exist on Windows.

## Test plan
- [x] Added a regression test (`tests/hooks/control-start.test.mjs`, describe block "foreign-server pairing works without lsof (Windows regression)") that spins up a real mock dashboard server implementing `/` + authenticated `/api/status`, forces `runConfirm` into the foreign-server pairing branch, and asserts `dashboard-token` and `known-projects.json` get written.
- [x] Verified the new test **fails** against the pre-fix code (`git stash` of just the `.cjs` files) with the exact symptom described above, and **passes** against the fix.
- [x] `node -c` syntax-checked all three `.cjs` copies and the test file.
- [x] Ran `npx vitest run tests/hooks/control-start.test.mjs -t "foreign-server pairing"` — passes. (Note: the full unfiltered `control-start.test.mjs` suite crashes vitest's forked worker pool on my Windows dev machine even on unmodified `main` — verified via `git stash` — a pre-existing environment issue unrelated to this change, not something this PR introduces or fixes.)
- [x] `npx biome check` on changed files — no new errors (2 pre-existing CRLF-related format errors present with or without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)