### PR TITLE
fix(ui): Windows path bugs breaking Sessions/Memory/org-chart data, and Edge CDP rejection

### DIFF
--- a/packages/@monoes/monobrowse/src/browser/browser.ts
+++ b/packages/@monoes/monobrowse/src/browser/browser.ts
@@ -79,7 +79,10 @@ async function isChromeIdentity(port: number): Promise<boolean> {
     const res = await fetch(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(1000) });
     if (!res.ok) return false;
     const info = (await res.json()) as { Browser?: string };
-    return typeof info.Browser === 'string' && /chrom(e|ium)/i.test(info.Browser);
+    // Edge's Browser field is "Edg/<version>" with no "chrome"/"chromium"
+    // substring, even though it's Chromium-based and CDP-compatible —
+    // accept it alongside Chrome/Chromium rather than rejecting a valid target.
+    return typeof info.Browser === 'string' && /chrom(e|ium)|edg/i.test(info.Browser);
   } catch {
     return false;
   }

--- a/packages/@monomind/cli/src/ui/dashboard.html
+++ b/packages/@monomind/cli/src/ui/dashboard.html
@@ -2610,6 +2610,9 @@ function refreshCurrent() {
   renderView(currentView);
 }
 
+// Project paths may be Windows ('\') or POSIX ('/') — split on either.
+function baseName(p) { return String(p || '').split(/[\\/]/).filter(Boolean).pop() || ''; }
+
 // ── init ───────────────────────────────────────────────────
 async function init() {
   try {
@@ -2619,7 +2622,9 @@ async function init() {
     gitUser = gu;
     document.getElementById('sb-user').textContent = gu.name || gu.email || '—';
     document.getElementById('sb-path').textContent = DIR;
-    document.getElementById('sb-proj').textContent = DIR.split('/').filter(Boolean).pop() || '—';
+    const sbProjEl = document.getElementById('sb-proj');
+    sbProjEl.textContent = baseName(DIR) || '—';
+    sbProjEl.title = DIR;
     _showNavProjectCtx(DIR);
   } catch (_) {}
   // deep-link: ?sess=<id>&proj=<path>
@@ -2650,7 +2655,9 @@ async function init() {
       }
     } catch (_) {}
     DIR = projParam;
-    document.getElementById('sb-proj').textContent = DIR.split('/').filter(Boolean).pop() || '—';
+    const sbProjEl2 = document.getElementById('sb-proj');
+    sbProjEl2.textContent = baseName(DIR) || '—';
+    sbProjEl2.title = DIR;
     document.getElementById('sb-path').textContent = DIR;
     _showNavProjectCtx(DIR);
   }
@@ -2708,11 +2715,13 @@ async function apiFetch(url, timeout = 15000) {
 
 // ── project switching ──────────────────────────────────────
 function _showNavProjectCtx(path) {
-  const projName = (path || '').split('/').filter(Boolean).pop() || '';
+  const projName = baseName(path);
   const ctx = document.getElementById('nav-project-ctx');
   const hint = document.getElementById('nav-no-proj-hint');
   if (projName) {
-    document.getElementById('nav-proj-name').textContent = projName;
+    const nameEl = document.getElementById('nav-proj-name');
+    nameEl.textContent = projName;
+    nameEl.title = path;
     ctx.classList.add('visible');
     hint.style.display = 'none';
   } else {
@@ -2734,7 +2743,9 @@ function switchProject(path) {
   _mgLoaded = false;
   _mgGraph = null;
   window._mgRealTotals = null;
-  document.getElementById('sb-proj').textContent = path.split('/').filter(Boolean).pop() || '—';
+  const sbProjEl3 = document.getElementById('sb-proj');
+  sbProjEl3.textContent = baseName(path) || '—';
+  sbProjEl3.title = path;
   document.getElementById('sb-path').textContent = path;
   _showNavProjectCtx(path);
   viewRendered = {};
@@ -5982,13 +5993,22 @@ function v2RenderOrgChart() {
   const colorOf = (role, idx) => COLORS[_v2OrgIsLeader(role) ? 0 : (idx % (COLORS.length - 1)) + 1];
 
   // ── auto-generate edges ───────────────────────────────
+  // Prefer each role's actual reports_to over a flat leader fan-out — a
+  // multi-level org (specialist -> team lead -> director) should connect to
+  // its real manager, not skip straight to the top boss.
   let comms = Array.isArray(d.communication) ? [...d.communication] : [];
   if (!comms.length && roles.length > 1) {
     const _lr0 = roles.find(_v2OrgIsLeader) || roles[0];
-    comms = roles.filter(r => r.id !== _lr0.id).flatMap(r => [
-      { from: _lr0.id, to: r.id, type: 'command' },
-      { from: r.id, to: _lr0.id, type: 'report' },
-    ]);
+    const _roleIds = new Set(roles.map(r => r.id));
+    comms = roles.filter(r => r.id !== _lr0.id).flatMap(r => {
+      const parentId = (r.reports_to && r.reports_to !== r.id && _roleIds.has(r.reports_to))
+        ? r.reports_to
+        : _lr0.id;
+      return [
+        { from: parentId, to: r.id, type: 'command' },
+        { from: r.id, to: parentId, type: 'report' },
+      ];
+    });
   }
 
   // ── layout positions ──────────────────────────────────

--- a/packages/@monomind/cli/src/ui/server.mjs
+++ b/packages/@monomind/cli/src/ui/server.mjs
@@ -870,6 +870,15 @@ function bindServer(server, port) {
 const _slugPathCache = new Map();
 const _MAX_SLUG_CACHE = 200;
 
+// Inverse of resolveSlugToPath: absolute path -> ~/.claude/projects/<slug>
+// dir name. Claude Code's slug replaces every path separator AND the
+// Windows drive-letter colon with '-' (e.g. "C:\Users\x" -> "C--Users-x")
+// — replacing only '/' leaves Windows paths (all-backslash) completely
+// untouched, so every dir= lookup 404s and every project shows 0 sessions.
+function pathToSlug(d) {
+  return String(d).replace(/[\\/:]/g, '-');
+}
+
 function resolveSlugToPath(slug, projDir) {
   if (_slugPathCache.has(slug)) return _slugPathCache.get(slug);
   const resolved = _resolveSlugToPathUncached(slug, projDir);
@@ -921,7 +930,10 @@ function _resolveSlugToPathUncached(slug, projDir) {
           .find((l) => l.includes('"cwd"'));
         if (line) {
           const m = line.match(/"cwd"\s*:\s*"([^"]+)"/);
-          if (m?.[1]) return m[1];
+          // m[1] is the raw JSON-escaped text between the quotes (e.g. a
+          // Windows path's backslashes still escaped as \\) — unescape it
+          // properly instead of returning the escaped literal.
+          if (m?.[1]) { try { return JSON.parse(`"${m[1]}"`); } catch { return m[1]; } }
         }
       } catch {}
     }
@@ -2004,7 +2016,7 @@ export async function startServer({
         const qs = new URL(req.url, 'http://localhost').searchParams;
         const dir = qs.get('dir') || projectDir || process.cwd();
         const d = path.resolve(dir || process.cwd());
-        const slug = d.replace(/\//g, '-');
+        const slug = pathToSlug(d);
         const projectClaudeDir = path.join(os.homedir(), '.claude', 'projects', slug);
 
         let sessionFiles = [];
@@ -2177,7 +2189,7 @@ export async function startServer({
       }
       try {
         const d = path.resolve(dir || process.cwd());
-        const slug = d.replace(/\//g, '-');
+        const slug = pathToSlug(d);
         const projectClaudeDir = path.join(os.homedir(), '.claude', 'projects', slug);
         let sessionFiles = [];
         try {
@@ -2251,7 +2263,7 @@ export async function startServer({
         const dir = qs.get('dir') || projectDir || process.cwd();
         const limit = Math.min(parseInt(qs.get('limit') || '50', 10), 200);
         const d = path.resolve(dir || process.cwd());
-        const slug = d.replace(/\//g, '-');
+        const slug = pathToSlug(d);
         const projectClaudeDir = path.join(os.homedir(), '.claude', 'projects', slug);
         let sessionFiles = [];
         try {
@@ -2342,7 +2354,7 @@ export async function startServer({
         const qs = new URL(req.url, 'http://localhost').searchParams;
         const dir = qs.get('dir') || projectDir || process.cwd();
         const d = path.resolve(dir || process.cwd());
-        const slug = d.replace(/\//g, '-');
+        const slug = pathToSlug(d);
         const projectClaudeDir = path.join(os.homedir(), '.claude', 'projects', slug);
         let sessionFiles = [];
         try {
@@ -2416,7 +2428,7 @@ export async function startServer({
         const qs = new URL(req.url, 'http://localhost').searchParams;
         const dir = qs.get('dir') || projectDir || process.cwd();
         const d = path.resolve(dir || process.cwd());
-        const slug = d.replace(/\//g, '-');
+        const slug = pathToSlug(d);
         const projectClaudeDir = path.join(os.homedir(), '.claude', 'projects', slug);
         let sessionFiles = [];
         try {
@@ -2569,7 +2581,7 @@ export async function startServer({
             const projDir = path.join(projectsBase, slug);
             const projPath = resolveSlugToPath(slug, projDir);
             const name =
-              projPath.split('/').filter(Boolean).pop() ||
+              path.basename(projPath) ||
               slug.split('-').filter(Boolean).pop() ||
               slug;
             let sessionCount = 0;
@@ -2940,7 +2952,7 @@ export async function startServer({
         const dir = qs.get('dir') || projectDir || process.cwd();
         const d = path.resolve(dir || process.cwd());
         const homeDir = os.homedir();
-        const slug = d.replace(/\//g, '-');
+        const slug = pathToSlug(d);
         const memDir = path.join(homeDir, '.claude', 'projects', slug, 'memory');
 
         let files = [];
@@ -3042,7 +3054,7 @@ export async function startServer({
         try {
           const qs = new URL(req.url, 'http://localhost').searchParams;
           const d = path.resolve(qs.get('dir') || projectDir || process.cwd());
-          const slug = d.replace(/\//g, '-');
+          const slug = pathToSlug(d);
           const memDir = path.join(os.homedir(), '.claude', 'projects', slug, 'memory');
           const { filename, content } = JSON.parse(body);
           if (
@@ -3090,7 +3102,7 @@ export async function startServer({
         try {
           const qs = new URL(req.url, 'http://localhost').searchParams;
           const d = path.resolve(qs.get('dir') || projectDir || process.cwd());
-          const slug = d.replace(/\//g, '-');
+          const slug = pathToSlug(d);
           const memDir = path.join(os.homedir(), '.claude', 'projects', slug, 'memory');
           const { filename } = JSON.parse(body);
           if (
@@ -3161,7 +3173,7 @@ export async function startServer({
       try {
         const qs = new URL(req.url, 'http://localhost').searchParams;
         const d = path.resolve(qs.get('dir') || projectDir || process.cwd());
-        const slug = d.replace(/\//g, '-');
+        const slug = pathToSlug(d);
         const memDir = path.join(os.homedir(), '.claude', 'projects', slug, 'memory');
 
         let total = 0,
@@ -3467,7 +3479,7 @@ export async function startServer({
               // Try to extract ScheduleWakeup context from session JSONL
               let loopEntry = null;
               try {
-                const escaped = cwd.replace(/\//g, '-');
+                const escaped = pathToSlug(cwd);
                 const sessionFile = path.join(
                   os.homedir(),
                   '.claude',
@@ -3696,7 +3708,7 @@ export async function startServer({
       // match against every filename when sessionId is a very long string.
       const _rawSessId = qs.get('id') || '';
       const sessionId = _rawSessId.slice(0, 256);
-      const slug = d.replace(/\//g, '-');
+      const slug = pathToSlug(d);
       const projectClaudeDir = path.join(os.homedir(), '.claude', 'projects', slug);
       try {
         const files = fs
@@ -3768,7 +3780,7 @@ export async function startServer({
     if (req.method === 'GET' && url.startsWith('/api/events-stream')) {
       const qs = new URL(req.url, 'http://localhost').searchParams;
       const d = path.resolve(qs.get('dir') || projectDir || process.cwd());
-      const slug = d.replace(/\//g, '-');
+      const slug = pathToSlug(d);
       const projectClaudeDir = path.join(os.homedir(), '.claude', 'projects', slug);
       res.writeHead(200, {
         'Content-Type': 'text/event-stream',


### PR DESCRIPTION
## Summary
- **Sessions/Memory/tokens/events-stream tabs came up empty on Windows.** `server.mjs` built the `~/.claude/projects/<slug>` lookup with `d.replace(/\//g, '-')` — a no-op on Windows since paths use backslashes, so every `dir=` lookup 404'd. Added a shared `pathToSlug()` (replaces `\`, `/`, and `:`, matching Claude Code's real slug convention) and routed all 12 call sites through it. Also fixed a related bug where the `cwd`-from-session-file fallback returned the raw JSON-escaped path (doubled backslashes) instead of unescaping it.
- **Sidebar showed the full path instead of the project name** on Windows (same `'/'`-only split bug, in `dashboard.html`). Added a matching `baseName()` helper; the full path now only shows as a hover tooltip.
- **Org chart connected every role straight to the boss** instead of to each person's actual manager. `v2RenderOrgChart()` synthesized a flat leader-fan-out whenever no `communication` array was declared in the org config, ignoring `reports_to` entirely. Now walks the real reporting chain.
- **`monomind browse` was unusable on Windows machines without Chrome installed.** `monobrowse`'s Chrome-identity check rejected Microsoft Edge (`Browser: "Edg/<version>"`, no chrome/chromium substring) even though Edge is Chromium-based and CDP-compatible.

## Test plan
- [x] Verified via direct API calls that `/api/session-journal` went from 0 → 50 sessions for a real Windows project after the fix
- [x] Verified via `monomind browse` (after fixing the Edge-rejection bug) that the Sessions tab renders real data in the actual browser UI, with no console errors
- [x] Verified the org chart renders multi-level `reports_to` chains correctly (specialist → team lead → director), not a flat boss fan-out — screenshot in session
- [x] Confirmed the pre-existing `tsc` build errors (missing `fflate`, stale `@monoes/monograph` exports) are present on clean `origin/main` too — unrelated to this change

🤖 Generated with [monomind](https://github.com/monoes/monomind)

https://claude.ai/code/session_015XZozfSf2XWiXWZHc9btZV