### PR TITLE
fix(deps): add missing integrity hash for xlsx CDN tarball

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2915,7 +2915,7 @@ packages:
         optional: true
 
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz, integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==}
     version: 0.20.3
     engines: {node: '>=0.8'}
     hasBin: true


### PR DESCRIPTION
## Summary
`xlsx` is pulled from `cdn.sheetjs.com` rather than the npm registry, and its `pnpm-lock.yaml` entry never got an `integrity` field. `pnpm install --frozen-lockfile` — used by every CI job — fails immediately with `ERR_PNPM_MISSING_TARBALL_INTEGRITY` before a single test can run.

This is breaking **every** CI run repo-wide right now, including on `main`'s current HEAD (confirmed via `gh run list --branch main`), and is what's making PR #197's checks show all-red despite that PR's actual change being unrelated and mergeable.

## Fix
Added the SRI `integrity: sha512-...` hash for the tarball. Computed from the actual downloaded bytes and independently re-verified via a second separate download — both produced the identical hash:
```
sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==
```

## Test plan
- [x] Verified the failure reproduces identically across every job/platform in a recent CI run on PR #197 and on `main`'s latest run — same `ERR_PNPM_MISSING_TARBALL_INTEGRITY` at the install step, confirming this isn't caused by any particular PR's diff
- [x] Computed the SHA-512 integrity hash from the tarball twice, via two independent downloads — identical result both times
- [x] Diff is a single line — no other lockfile drift introduced

🤖 Generated with [monomind](https://github.com/monoes/monomind)

https://claude.ai/code/session_015XZozfSf2XWiXWZHc9btZV