### PR TITLE
fix(orgrt): #202/#203/#205/#206 org-runtime bugs

### DIFF
--- a/packages/@monomind/cli/__tests__/orgrt/daemon.test.ts
+++ b/packages/@monomind/cli/__tests__/orgrt/daemon.test.ts
@@ -371,7 +371,36 @@ describe('OrgDaemon — completion & idle watchdog', () => {
     expect(running.busEvents().some(e => e.type === 'status' && e.msg === 'org stopped')).toBe(true);
     const rt = JSON.parse(readFileSync(join(root, '.monomind/orgs/alpha/runtime.json'), 'utf8'));
     expect(rt.status).toBe('stopped');
+    // #206: the ONLY signal `org run` trusts for a clean exit — must be set
+    // by the org-complete auto-stop path all the way through to disk.
+    expect(rt.closedBy).toBe('org-complete');
   }, 10_000);
+
+  it('#206: a stop NOT triggered by org_complete (idle watchdog) leaves closedBy unset in runtime.json', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'daemon-idle-noclosedby-'));
+    mkdirSync(join(root, '.monomind/orgs'), { recursive: true });
+    writeFileSync(join(root, '.monomind/orgs/alpha.json'), JSON.stringify({
+      name: 'alpha', goal: 'g',
+      run_config: { idle_minutes: 0.005 },
+      roles: [
+        { id: 'boss', title: 'Boss', type: 'boss', reports_to: null },
+        { id: 'coder', title: 'Coder', type: 'specialist', reports_to: 'boss' },
+      ],
+    }));
+    const hangingQuery = () => (async function* () { await new Promise(() => {}); })();
+    const d = new OrgDaemon(root, { queryFn: hangingQuery as any, forward: false, stopWaitMs: 200 });
+    await d.startOrg('alpha');
+    const deadline = Date.now() + 8000;
+    while (d.getOrg('alpha') && Date.now() < deadline) await new Promise(r => setTimeout(r, 100));
+    expect(d.getOrg('alpha')).toBeUndefined();
+    // mirrors `org run`: stopAll() must JOIN the detached in-flight idle-stop
+    // so runtime.json has actually landed before we read it (same race the
+    // org-complete test above documents).
+    await d.stopAll();
+    const rt = JSON.parse(readFileSync(join(root, '.monomind/orgs/alpha/runtime.json'), 'utf8'));
+    expect(rt.status).toBe('stopped');
+    expect(rt.closedBy).toBeUndefined();
+  }, 15_000);
 
   it('idle watchdog nudges the boss, then stops the org when the nudge produces no activity (hung agent)', async () => {
     const root = mkdtempSync(join(tmpdir(), 'daemon-idle-'));
@@ -393,6 +422,33 @@ describe('OrgDaemon — completion & idle watchdog', () => {
     const events = running.busEvents();
     expect(events.some(e => e.type === 'audit' && e.reason === 'idle-nudge')).toBe(true);
     expect(events.some(e => e.type === 'audit' && e.reason === 'idle-stop')).toBe(true);
+    expect(d.getOrg('alpha')).toBeUndefined();
+  }, 15_000);
+
+  it('#205: idle watchdog reports a budget-exhausted boss distinctly, not as generic "unreachable"', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'daemon-idle-budget-'));
+    mkdirSync(join(root, '.monomind/orgs'), { recursive: true });
+    writeFileSync(join(root, '.monomind/orgs/alpha.json'), JSON.stringify({
+      name: 'alpha', goal: 'g',
+      run_config: { idle_minutes: 0.005 }, // 300ms idle window for the test
+      roles: [
+        { id: 'boss', title: 'Boss', type: 'boss', reports_to: null },
+        { id: 'coder', title: 'Coder', type: 'specialist', reports_to: 'boss' },
+      ],
+    }));
+    const hangingQuery = () => (async function* () { await new Promise(() => {}); })();
+    const d = new OrgDaemon(root, { queryFn: hangingQuery as any, forward: false, stopWaitMs: 200 });
+    const running = await d.startOrg('alpha');
+    // Simulate what session.ts does on token-budget exhaustion, without
+    // needing a real budget-tracking session: close the boss's own mailbox
+    // with the same reason it would pass.
+    running.agents.get('boss')!.mailbox.close('token-budget');
+    const deadline = Date.now() + 8000;
+    while (d.getOrg('alpha') && Date.now() < deadline) await new Promise(r => setTimeout(r, 100));
+    const events = running.busEvents();
+    const stopEvent = events.find(e => e.type === 'audit' && e.reason === 'idle-stop');
+    expect(stopEvent?.msg).toMatch(/budget/i);
+    expect(stopEvent?.msg).not.toMatch(/unreachable/i);
     expect(d.getOrg('alpha')).toBeUndefined();
   }, 15_000);
 

--- a/packages/@monomind/cli/__tests__/orgrt/mailbox.test.ts
+++ b/packages/@monomind/cli/__tests__/orgrt/mailbox.test.ts
@@ -99,3 +99,90 @@ describe('restart-window message safety (swarm finding #2)', () => {
     expect(next.done).toBe(true);
   });
 });
+
+describe('reclaimInFlight (#203: crash-retry parking the session forever)', () => {
+  it('puts a mid-flight message back at the front of the queue when the generator is abandoned mid-yield', async () => {
+    const mb = new Mailbox();
+    mb.push('crashed-turn');
+    const gen1 = mb.stream('s1');
+    const first = await gen1.next(); // shift()ed and yielded, but the "session" now dies before asking for more
+    expect(first.value.message.content).toBe('crashed-turn');
+    expect(mb.consumedRealCount).toBe(1);
+
+    // This is what daemon.ts's crash-retry catch block does.
+    mb.detach();
+    mb.reclaimInFlight();
+    expect(mb.consumedRealCount).toBe(0); // undone — it was never actually processed
+
+    const gen2 = mb.stream('s2');
+    const redelivered = await gen2.next();
+    expect(redelivered.done).toBe(false);
+    expect(redelivered.value.message.content).toBe('crashed-turn');
+    mb.close();
+  });
+
+  it('is a no-op when the prior turn completed cleanly (generator was resumed for another pull)', async () => {
+    const mb = new Mailbox();
+    mb.push('turn-1');
+    const gen1 = mb.stream('s1');
+    await gen1.next(); // consume turn-1
+    const parked = gen1.next(); // ask for more with an empty queue — proves turn-1 finished; inFlight clears even though this pull itself won't resolve yet
+    await new Promise((r) => setTimeout(r, 5));
+    mb.detach();
+    mb.reclaimInFlight(); // nothing to reclaim — turn-1 was confirmed delivered
+    expect(mb.consumedRealCount).toBe(1); // unchanged — not undone
+    const gen2 = mb.stream('s2');
+    mb.close();
+    const next = await gen2.next();
+    expect(next.done).toBe(true); // turn-1 was already delivered to gen1, not lost, not redelivered
+    void parked; // abandoned along with gen1 — never resolves, matches existing detach() behavior
+  });
+
+  it('is a no-op when nothing was ever pulled', () => {
+    const mb = new Mailbox();
+    mb.push('never-pulled');
+    mb.reclaimInFlight();
+    expect(mb.consumedRealCount).toBe(0);
+  });
+
+  it('does not decrement consumedRealCount for a reclaimed continuation-prefix message', async () => {
+    const mb = new Mailbox();
+    mb.push(`${Mailbox.CONTINUE_PREFIX} continue please`);
+    const gen1 = mb.stream('s1');
+    await gen1.next();
+    expect(mb.consumedRealCount).toBe(0); // continuation pushes never increment it
+    mb.reclaimInFlight();
+    expect(mb.consumedRealCount).toBe(0); // still 0 — nothing to undo
+  });
+});
+
+describe('closeReason (#205: budget-exhausted boss vs. genuinely unreachable)', () => {
+  it('defaults to undefined for a plain close()', () => {
+    const mb = new Mailbox();
+    mb.close();
+    expect(mb.closeReason).toBeUndefined();
+  });
+
+  it('records the reason passed to close()', () => {
+    const mb = new Mailbox();
+    mb.close('token-budget');
+    expect(mb.isClosed).toBe(true);
+    expect(mb.closeReason).toBe('token-budget');
+  });
+
+  it('round-trips through serialize()/deserialize()', () => {
+    const mb = new Mailbox();
+    mb.close('usd-budget');
+    const state = mb.serialize();
+    const restored = new Mailbox();
+    restored.deserialize(state);
+    expect(restored.isClosed).toBe(true);
+    expect(restored.closeReason).toBe('usd-budget');
+  });
+
+  it('deserializes an older checkpoint with no closeReason field as undefined', () => {
+    const mb = new Mailbox();
+    mb.deserialize({ queue: [], closed: true, consumedReal: 0 });
+    expect(mb.closeReason).toBeUndefined();
+  });
+});

--- a/packages/@monomind/cli/__tests__/orgrt/schedule-boss-restart-exhausted.test.ts
+++ b/packages/@monomind/cli/__tests__/orgrt/schedule-boss-restart-exhausted.test.ts
@@ -1,0 +1,55 @@
+/**
+ * #206 companion fix: once scheduleBossRestart() gives up after
+ * MAX_BOSS_RESTARTS, it used to only emit a 'boss-restart-exhausted' audit
+ * event and return — the org stayed in daemon.orgs forever with a dead boss
+ * mailbox, since nothing else was left to call stopOrg for it (the idle
+ * watchdog only fires if idle_minutes > 0). `org run`'s wait loop
+ * (`while (!daemon.getOrg(name))`) would then never exit. It must actually
+ * stop the org.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { scheduleBossRestart } from '../../src/orgrt/scheduler-integration.js';
+import { OrgDaemon } from '../../src/orgrt/daemon.js';
+
+function stubDaemon(name: string, restartCount: number) {
+  const events: unknown[] = [];
+  const stopOrg = vi.fn(async () => {});
+  const daemon = {
+    stopping: new Map<string, unknown>(),
+    restarting: new Set<string>(),
+    bossRestartCounts: new Map<string, number>([[name, restartCount]]),
+    orgs: new Map([[name, { bus: { emit: (e: unknown) => events.push(e) } }]]),
+    opts: {},
+    stopOrg,
+  } as unknown as OrgDaemon;
+  return { daemon, events, stopOrg };
+}
+
+describe('scheduleBossRestart — exhausted-retries path', () => {
+  it('calls daemon.stopOrg once the restart cap is reached, so the org actually terminates', () => {
+    const { daemon, events, stopOrg } = stubDaemon('alpha', OrgDaemon.MAX_BOSS_RESTARTS);
+    scheduleBossRestart(daemon, 'alpha');
+    expect(stopOrg).toHaveBeenCalledWith('alpha');
+    expect(events.some((e) => (e as { reason?: string }).reason === 'boss-restart-exhausted')).toBe(true);
+  });
+
+  it('does NOT call stopOrg while restarts remain (schedules a restart instead)', () => {
+    const { daemon, stopOrg } = stubDaemon('alpha', 0);
+    scheduleBossRestart(daemon, 'alpha');
+    expect(stopOrg).not.toHaveBeenCalled();
+  });
+
+  it('a stopOrg rejection is caught, not thrown synchronously out of scheduleBossRestart', () => {
+    const name = 'alpha';
+    const events: unknown[] = [];
+    const daemon = {
+      stopping: new Map<string, unknown>(),
+      restarting: new Set<string>(),
+      bossRestartCounts: new Map<string, number>([[name, OrgDaemon.MAX_BOSS_RESTARTS]]),
+      orgs: new Map([[name, { bus: { emit: (e: unknown) => events.push(e) } }]]),
+      opts: {},
+      stopOrg: vi.fn(async () => { throw new Error('stop boom'); }),
+    } as unknown as OrgDaemon;
+    expect(() => scheduleBossRestart(daemon, name)).not.toThrow();
+  });
+});

--- a/packages/@monomind/cli/src/__tests__/org-run-outcome.test.ts
+++ b/packages/@monomind/cli/src/__tests__/org-run-outcome.test.ts
@@ -1,0 +1,56 @@
+/**
+ * #206: `monomind org run <name>` used to exit 0 unconditionally once the
+ * run stopped, whether it completed its goal, was stopped by the idle
+ * watchdog, or crashed — scripts and process supervisors (launchd/systemd)
+ * driving off the exit code couldn't tell success from failure.
+ *
+ * `runOutcomeResult` is the extracted decision runAction makes after
+ * re-reading runtime.json's final state (mirrors resolvedIdleNudgeCount's
+ * precedent for the idle watchdog — a pure decision pulled out of a command
+ * handler so it's testable without a real daemon/org).
+ */
+import { describe, it, expect } from 'vitest';
+import { runOutcomeResult } from '../commands/org.js';
+
+describe('runOutcomeResult', () => {
+  it('exits 0 on a clean, goal-driven completion (closedBy: org-complete)', () => {
+    const result = runOutcomeResult('alpha', { status: 'stopped', closedBy: 'org-complete' });
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBeUndefined();
+  });
+
+  it('exits 1 with the recorded error on a process-level crash', () => {
+    const result = runOutcomeResult('alpha', { status: 'crashed', error: 'FATAL 403 quota error' });
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain('FATAL 403 quota error');
+  });
+
+  it('exits 1 with a generic unknown-error message when crashed with no recorded error', () => {
+    const result = runOutcomeResult('alpha', { status: 'crashed' });
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toContain('unknown error');
+  });
+
+  it('exits 1 when the run stopped without org_complete (idle watchdog / boss-restart-exhausted)', () => {
+    // status: 'stopped' with no closedBy — exactly what idleStop() and
+    // scheduleBossRestart's give-up path leave behind.
+    const result = runOutcomeResult('alpha', { status: 'stopped' });
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.message).toMatch(/not via org_complete/);
+  });
+
+  it('exits 1 when runtime.json could not be read at all (empty state)', () => {
+    const result = runOutcomeResult('alpha', {});
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('a status of "running" (e.g. the CLI itself was SIGKILLed, nothing updated runtime.json) is treated as non-clean, not success', () => {
+    const result = runOutcomeResult('alpha', { status: 'running' });
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/packages/@monomind/cli/src/__tests__/tool-fence.test.ts
+++ b/packages/@monomind/cli/src/__tests__/tool-fence.test.ts
@@ -91,4 +91,40 @@ describe('parseToolCalls', () => {
     expect(calls).toHaveLength(1);
     expect((calls[0].arguments as { message: string }).message).toBe('use { and }');
   });
+
+  // #202: a fence cut off before its closing ``` (the model hit its
+  // per-response output limit mid-argument) never matches TOOL_CALL_RE at
+  // all, so it used to be silently dropped — no tool executed, no feedback,
+  // the model believing its call succeeded.
+  it('reports a truncated fence (no closing ```) via onMalformed and executes nothing', () => {
+    const text = '```tool_call\n{"name": "org_gate", "arguments": {"name": "publish", "description": "a very long description that got cut off mid';
+    const onMalformed = vi.fn();
+    const calls = parseToolCalls([text], onMalformed);
+    expect(calls).toEqual([]);
+    expect(onMalformed).toHaveBeenCalledTimes(1);
+    const [raw, err] = onMalformed.mock.calls[0] as [string, string];
+    expect(raw).toContain('org_gate');
+    expect(err).toMatch(/truncated/i);
+  });
+
+  it('does not flag a well-formed fence as truncated', () => {
+    const text = fence('{"name": "org_send", "arguments": {"to": "a", "message": "hi"}}');
+    const onMalformed = vi.fn();
+    const calls = parseToolCalls([text], onMalformed);
+    expect(calls).toHaveLength(1);
+    expect(onMalformed).not.toHaveBeenCalled();
+  });
+
+  it('flags a truncated fence following a well-formed one, without re-flagging the well-formed one', () => {
+    const text =
+      fence('{"name": "org_send", "arguments": {"to": "a", "message": "1"}}') +
+      '\n```tool_call\n{"name": "org_gate", "arguments": {"description": "cut off mid';
+    const onMalformed = vi.fn();
+    const calls = parseToolCalls([text], onMalformed);
+    expect(calls.map((c) => c.name)).toEqual(['org_send']);
+    expect(onMalformed).toHaveBeenCalledTimes(1);
+    const [raw, err] = onMalformed.mock.calls[0] as [string, string];
+    expect(raw).toContain('org_gate');
+    expect(err).toMatch(/truncated/i);
+  });
 });

--- a/packages/@monomind/cli/src/commands/org.ts
+++ b/packages/@monomind/cli/src/commands/org.ts
@@ -348,9 +348,14 @@ const runAction = async (ctx: CommandContext): Promise<CommandResult> => {
   // previous run before polling.
   clearStopfile(ctx.cwd, name);
   const stopfile = join(ctx.cwd, ORG_DIR, name, 'stop');
+  // #206: a human explicitly running `monomind org stop` is a deliberate,
+  // successful action regardless of how the run itself ended — capture that
+  // BEFORE clearStopfile() below wipes the file, so it isn't lost.
+  let stoppedManually = false;
   await new Promise<void>(resolvePromise => {
     const iv = setInterval(() => {
-      if (existsSync(stopfile) || !daemon.getOrg(name)) { clearInterval(iv); resolvePromise(); }
+      if (existsSync(stopfile)) { stoppedManually = true; clearInterval(iv); resolvePromise(); }
+      else if (!daemon.getOrg(name)) { clearInterval(iv); resolvePromise(); }
     }, 2000);
     process.once('SIGINT', () => { clearInterval(iv); resolvePromise(); });
     process.once('SIGTERM', () => { clearInterval(iv); resolvePromise(); });
@@ -358,8 +363,46 @@ const runAction = async (ctx: CommandContext): Promise<CommandResult> => {
   clearStopfile(ctx.cwd, name);
   await daemon.stopAll();
   srv?.close();
-  return { success: true, message: `org ${name} stopped` };
+
+  if (stoppedManually) return { success: true, message: `org ${name} stopped` };
+
+  // #206: 'org run' used to exit 0 unconditionally here — a crashed or
+  // watchdog-stopped run was indistinguishable from a completed one to any
+  // script or supervisor (launchd/systemd) driving off the exit code. Re-read
+  // the daemon's final record (same runtime.json pattern isOrgRunning/
+  // statusAction already use below) and only report success for a run that
+  // actually finished its goal via org_complete.
+  let final: RunTerminalState = {};
+  try {
+    final = JSON.parse(readFileSync(join(ctx.cwd, ORG_DIR, name, 'runtime.json'), 'utf8'));
+  } catch { /* best-effort — falls through to the non-clean-stop case below */ }
+
+  return runOutcomeResult(name, final);
 };
+
+/** Just the fields determineRunOutcome needs from runtime.json. */
+type RunTerminalState = { status?: string; closedBy?: string; error?: string };
+
+/** Decides `org run`'s exit-code-bearing CommandResult from the run's final
+ *  recorded state. Extracted (matching resolvedIdleNudgeCount's precedent for
+ *  the idle watchdog) so this decision is unit-testable without spinning up a
+ *  real daemon/org. Exit 0 ONLY for a clean, goal-driven end (closedBy:
+ *  'org-complete', set by daemon.ts's org-complete auto-stop path) — every
+ *  other outcome (idle-watchdog stop, boss-restart-exhausted, a process-level
+ *  crash) exits 1 so scripts/supervisors can tell success from failure. */
+export function runOutcomeResult(name: string, final: RunTerminalState): CommandResult {
+  if (final.closedBy === 'org-complete') {
+    return { success: true, message: `org ${name} completed` };
+  }
+  if (final.status === 'crashed') {
+    return { success: false, message: `org ${name} crashed: ${final.error ?? 'unknown error'}`, exitCode: 1 };
+  }
+  return {
+    success: false,
+    message: `org ${name} stopped without completing (not via org_complete) — check 'monomind org status ${name}' or the run history for the reason`,
+    exitCode: 1,
+  };
+}
 
 /** True when runtime.json records a running org whose recorded pid is still alive. */
 const isOrgRunning = (cwd: string, name: string): boolean => {

--- a/packages/@monomind/cli/src/orgrt/daemon.ts
+++ b/packages/@monomind/cli/src/orgrt/daemon.ts
@@ -657,7 +657,11 @@ export class OrgDaemon {
       // against a concurrent manual stop.
       if (e.type === 'status' && e.reason === 'org-complete') {
         const t = setTimeout(() => {
-          this.stopOrg(name, { drainMs: COMPLETE_DRAIN_MS }).catch((err) =>
+          // #206: closedBy: 'org-complete' is the ONLY signal `org run`
+          // trusts to mean "the run ended cleanly, exit 0" — every other
+          // stop path (idle watchdog, boss-restart-exhausted, manual stop)
+          // leaves it unset.
+          this.stopOrg(name, { drainMs: COMPLETE_DRAIN_MS, closedBy: 'org-complete' }).catch((err) =>
             console.error(
               `org ${name}: auto-stop after org_complete failed:`,
               err instanceof Error ? err.message : err,
@@ -1010,6 +1014,12 @@ export class OrgDaemon {
             // during the backoff window must queue for the NEXT session, not
             // wake the dead generator to swallow it.
             mailbox.detach();
+            // #203: if the crashed session's mailbox generator was abandoned
+            // mid-yield (message already shift()ed for it, turn never
+            // finished), put that message back on the queue — otherwise the
+            // replacement session's stream() finds an empty queue and parks
+            // forever, since the "delivered" message is gone for good.
+            mailbox.reclaimInFlight();
             const message = err instanceof Error ? err.message : String(err);
             const isTurnLimit = /Reached maximum number of turns|error_max_turns/i.test(message);
             // Bounded like every other recovery: attempt counts every pass
@@ -1304,6 +1314,20 @@ export class OrgDaemon {
               return;
             }
             const bossRt = running.agents.get(bossRole.id);
+            // #205: a budget-exhausted boss closed its own mailbox on
+            // purpose (session.ts) — that's a recoverable pause, not the
+            // same "unreachable" condition as a crash. Name it distinctly so
+            // the operator's remedy (raise the budget, resume) is obvious
+            // instead of reading like the run died.
+            const budgetReason = bossRt?.mailbox.closeReason;
+            if (budgetReason === 'token-budget' || budgetReason === 'usd-budget') {
+              idleStop(
+                `org idle for ${Math.round(idleFor / 60_000)}m and boss "${bossRole.id}" is over its ` +
+                  `${budgetReason === 'token-budget' ? 'token' : 'USD'} budget — raise the role's ` +
+                  `${budgetReason === 'token-budget' ? 'budget_tokens' : 'budget_usd'} (or run_config's) and resume from checkpoint — stopping run`,
+              );
+              return;
+            }
             if (!bossRt || bossRt.status !== 'running' || bossRt.mailbox.isClosed) {
               idleStop(
                 `org idle for ${Math.round(idleFor / 60_000)}m and boss "${bossRole.id}" is unreachable — stopping run`,
@@ -1396,8 +1420,13 @@ export class OrgDaemon {
 
   /** @param opts.drainMs how long to let in-flight agent sessions finish before
    *  reaping. Defaults to the short abort bound; the planned-completion path
-   *  passes a far longer window (see COMPLETE_DRAIN_MS). */
-  async stopOrg(name: string, opts?: { drainMs?: number }): Promise<void> {
+   *  passes a far longer window (see COMPLETE_DRAIN_MS).
+   *  @param opts.closedBy #206: tags WHY the run ended, persisted into
+   *  runtime.json so `org run` can tell a clean, goal-driven end
+   *  (closedBy: 'org-complete') from every other kind of stop (idle
+   *  watchdog, boss-restart-exhausted, manual `org stop`) and exit non-zero
+   *  for the latter. Only the org_complete auto-stop path passes this. */
+  async stopOrg(name: string, opts?: { drainMs?: number; closedBy?: string }): Promise<void> {
     // Join an in-flight stop instead of no-oping: the self-stop paths
     // (org_complete, idle watchdog) run detached, and a caller like
     // `org run`'s final stopAll() must not resolve — letting the process
@@ -1414,7 +1443,7 @@ export class OrgDaemon {
     // shutdown via `stopping` instead of re-running the whole sequence and
     // double-emitting 'org stopped' (duplicate org:complete/session:complete).
     this.orgs.delete(name);
-    const p = this.finishStop(name, org, opts?.drainMs);
+    const p = this.finishStop(name, org, opts?.drainMs, opts?.closedBy);
     this.stopping.set(name, p);
     try {
       await p;
@@ -1423,7 +1452,7 @@ export class OrgDaemon {
     }
   }
 
-  private async finishStop(name: string, org: RunningOrg, drainMs?: number): Promise<void> {
+  private async finishStop(name: string, org: RunningOrg, drainMs?: number, closedBy?: string): Promise<void> {
     // Snapshot checkpoint BEFORE closing mailboxes / draining sessions — the
     // queue is emptied during the drain, so capturing afterwards loses all
     // unconsumed messages (the whole point of checkpoint-resume).
@@ -1539,7 +1568,7 @@ export class OrgDaemon {
     // Same guard for runtime.json: if a new run started during shutdown, its
     // 'running' record must not be overwritten with this old run's 'stopped'.
     // Pass the org directly since we already removed it from the map.
-    if (!this.orgs.has(name)) this.persistState(name, 'stopped', org.run, org, stopCheckpoint);
+    if (!this.orgs.has(name)) this.persistState(name, 'stopped', org.run, org, stopCheckpoint, closedBy);
     // Clean up git worktrees — shared (workspace: 'worktree') and per-role.
     try {
       const { execFileSync } = await import('node:child_process');
@@ -1579,13 +1608,19 @@ export class OrgDaemon {
     ]);
   }
 
-  /** @internal */
+  /** @internal
+   *  @param closedBy #206: why the run ended — 'org-complete' for a clean,
+   *  goal-driven end (the only value any caller currently passes); absent for
+   *  every other stop (idle watchdog, boss-restart-exhausted, manual `org
+   *  stop`). Mirrors persistCrashStateAll()'s existing closedBy: 'crash-handler'
+   *  for the process-crash path, which org.ts already reads. */
   persistState(
     name: string,
     status: string,
     run: string,
     org?: RunningOrg,
     checkpointOverride?: OrgCheckpoint | null,
+    closedBy?: string,
   ): void {
     const p = join(this.root, ORG_DIR, name, 'runtime.json');
     const missing = [...(this.abandoned.get(name) ?? [])];
@@ -1616,6 +1651,7 @@ export class OrgDaemon {
       updated: new Date().toISOString(),
       ...(missing.length ? { abandonedRoles: missing } : {}),
       ...(checkpoint ? { checkpoint } : {}),
+      ...(closedBy ? { closedBy } : {}),
     });
   }
 

--- a/packages/@monomind/cli/src/orgrt/mailbox.ts
+++ b/packages/@monomind/cli/src/orgrt/mailbox.ts
@@ -20,11 +20,21 @@ export class Mailbox {
   private queue: string[] = [];
   private wake: (() => void) | null = null;
   private closed = false;
+  /** Why close() was called — e.g. 'token-budget' / 'usd-budget' — distinct
+   *  from a crash/terminal close (undefined). Lets callers like the idle
+   *  watchdog tell a recoverable budget pause from genuine unreachability. */
+  private closeReasonValue?: string;
   /** Bumped when a new stream() starts; stale generators see the mismatch and exit. */
   private generation = 0;
   /** Monotonic count of REAL (non-continuation) messages consumed by stream().
    *  The restart loop snapshots this around a session to tell progress from spin. */
   private consumedReal = 0;
+  /** The most recently shift()ed-but-not-yet-confirmed-processed message: set
+   *  right before stream() yields it, cleared once the generator is resumed
+   *  for the next pull (proof the runner asked for more, i.e. the prior turn
+   *  finished). If a session dies with this still set, the generator was
+   *  abandoned mid-yield — see reclaimInFlight(). */
+  private inFlight: string | null = null;
 
   /** Number of real (non-continuation) messages consumed so far across all sessions. */
   get consumedRealCount(): number { return this.consumedReal; }
@@ -38,12 +48,17 @@ export class Mailbox {
     this.wake?.(); this.wake = null;
   }
 
-  close(): void {
+  close(reason?: string): void {
     this.closed = true;
+    this.closeReasonValue = reason;
     this.wake?.(); this.wake = null;
   }
 
   get isClosed(): boolean { return this.closed; }
+
+  /** Why close() was called, if given a reason — undefined for a plain crash/
+   *  terminal close. See the closeReasonValue field doc for intent. */
+  get closeReason(): string | undefined { return this.closeReasonValue; }
 
   /**
    * Detach the current waker WITHOUT resolving it. Called between sessions
@@ -71,11 +86,16 @@ export class Mailbox {
     const gen = ++this.generation;
     // Drop (never resolve) any stale waker — see detach().
     this.wake = null;
+    // A fresh generator starts with nothing in flight — any prior value
+    // belonged to a now-dead generator and reclaimInFlight() (called from the
+    // crash-retry path, if at all) already had its chance to act on it.
+    this.inFlight = null;
     while (true) {
       while (this.queue.length > 0) {
         if (gen !== this.generation) return; // superseded — leave the queue for the live generator
         const content = this.queue.shift()!;
         if (!content.startsWith(Mailbox.CONTINUE_PREFIX)) this.consumedReal++;
+        this.inFlight = content;
         yield {
           type: 'user',
           message: { role: 'user', content },
@@ -83,6 +103,10 @@ export class Mailbox {
           session_id: sessionId,
         };
         if (gen !== this.generation) return;
+        // Resumed for another pull: the consumer asked for the next message,
+        // which only happens once it's done with this one — proof the prior
+        // turn completed rather than the session dying mid-processing.
+        this.inFlight = null;
       }
       if (this.closed || gen !== this.generation) return;
       await new Promise<void>(r => { this.wake = r; });
@@ -90,22 +114,45 @@ export class Mailbox {
     }
   }
 
+  /** Called by the crash-retry path right after a session dies abnormally. If
+   *  a message was mid-flight — shifted for the crashed generator's yield but
+   *  never confirmed processed, because the generator was abandoned at that
+   *  yield rather than resumed for another pull — put it back at the front of
+   *  the queue so the replacement session (built by the next stream() call)
+   *  gets it first instead of the queue staying empty and the new session
+   *  parking on the mailbox forever. A no-op when nothing was in flight
+   *  (clean session end, or nothing was ever pulled). */
+  reclaimInFlight(): void {
+    if (this.inFlight === null) return;
+    const content = this.inFlight;
+    this.inFlight = null;
+    this.queue.unshift(content);
+    // Undo the increment made when this message was shifted — it was never
+    // actually processed, so the restart loop's progress/spin detection
+    // should not count it as consumed.
+    if (!content.startsWith(Mailbox.CONTINUE_PREFIX)) this.consumedReal--;
+  }
+
   /** Serialize mailbox state for checkpoint/resume - Pattern 3 */
-  serialize(): { queue: string[]; closed: boolean; consumedReal: number } {
+  serialize(): { queue: string[]; closed: boolean; consumedReal: number; closeReason?: string } {
     return {
       queue: [...this.queue], // Copy array - queue is public for checkpoint access
       closed: this.closed,
       consumedReal: this.consumedReal,
+      ...(this.closeReasonValue ? { closeReason: this.closeReasonValue } : {}),
     };
   }
 
   /** Deserialize mailbox state from checkpoint - Pattern 3 */
-  deserialize(state: { queue: string[]; closed: boolean; consumedReal: number }): void {
+  deserialize(state: { queue: string[]; closed: boolean; consumedReal: number; closeReason?: string }): void {
     this.queue = [...state.queue]; // Restore queue content
     this.closed = state.closed;
     this.consumedReal = state.consumedReal;
-    // Reset generation and wake - a new stream() call will set fresh values
+    this.closeReasonValue = state.closeReason; // undefined for checkpoints predating this field
+    // Reset generation, wake, and in-flight tracking - a new stream() call
+    // will set fresh values; nothing from a checkpointed run is "in flight".
     this.generation = 0;
     this.wake = null;
+    this.inFlight = null;
   }
 }

--- a/packages/@monomind/cli/src/orgrt/scheduler-integration.ts
+++ b/packages/@monomind/cli/src/orgrt/scheduler-integration.ts
@@ -28,6 +28,14 @@ export function scheduleBossRestart(daemon: OrgDaemon, name: string): void {
   if (count >= OrgDaemon.MAX_BOSS_RESTARTS) {
     bus?.emit({ type: 'audit', reason: 'boss-restart-exhausted',
       msg: `boss crashed again after ${count} auto-restart(s) — giving up; manual restart required` });
+    // #206: without this the org was left dangling in daemon.orgs forever —
+    // its boss mailbox already closed from the crash, nothing else left to
+    // ever call stopOrg for it (the idle watchdog only fires if
+    // idle_minutes > 0). `org run`'s wait loop polls daemon.getOrg(name);
+    // that never resolving meant the CLI process just hung indefinitely
+    // instead of exiting with a failure signal.
+    daemon.stopOrg(name).catch(err =>
+      console.error(`org ${name}: stop after exhausted boss restarts failed:`, err instanceof Error ? err.message : err));
     return;
   }
   const backoffSchedule = daemon.opts.bossRestartBackoffMs ?? OrgDaemon.BOSS_RESTART_BACKOFF_MS;

--- a/packages/@monomind/cli/src/orgrt/session.ts
+++ b/packages/@monomind/cli/src/orgrt/session.ts
@@ -571,13 +571,16 @@ async function runOneSession(opts: SessionOpts, resume?: string, costTotals?: Ma
           opts.circuitBreaker.state.failures = 0;
         }
         if (policy.overBudget) {
-          bus.emit({ type: 'status', from: role.id, msg: 'token budget exhausted - closing session' });
-          mailbox.close();
+          bus.emit({ type: 'status', from: role.id, reason: 'budget-exhausted', msg: 'token budget exhausted - closing session' });
+          // #205: tag WHY the mailbox closed. A budget-exhausted boss is
+          // recoverable (raise the budget, resume) — the idle watchdog reads
+          // this to stop reporting it as generic "unreachable" (crash-like).
+          mailbox.close('token-budget');
         }
         // ORG-7: parallel USD-budget enforcement, same pattern as the token check above.
         if (policy.overBudgetUsd) {
           bus.emit({ type: 'status', from: role.id, reason: 'budget-exhausted', msg: 'USD budget exhausted - closing session' });
-          mailbox.close();
+          mailbox.close('usd-budget');
         }
       }
     }

--- a/packages/@monomind/cli/src/orgrt/tool-fence.ts
+++ b/packages/@monomind/cli/src/orgrt/tool-fence.ts
@@ -128,7 +128,9 @@ export function parseToolCalls(
   for (const text of rawTexts) {
     TOOL_CALL_RE.lastIndex = 0;
     let m: RegExpExecArray | null;
+    let lastMatchEnd = 0;
     while ((m = TOOL_CALL_RE.exec(text)) !== null) {
+      lastMatchEnd = TOOL_CALL_RE.lastIndex;
       try {
         // Models sometimes append extra closing braces after the JSON object
         // (observed with kimi k3: `...}}}`); parse only the first balanced
@@ -144,6 +146,22 @@ export function parseToolCalls(
       } catch (err) {
         onMalformed?.(m[1].trim(), err instanceof Error ? err.message : String(err));
       }
+    }
+    // A ```tool_call opener with no closing ``` anywhere after it (the model
+    // hit its per-response output limit mid-argument) never matches
+    // TOOL_CALL_RE at all — the regex requires both fences. Left undetected,
+    // the tool silently never executes and the model believes it did. Flag
+    // any opener that starts at or after the last successful match's end as
+    // truncated, distinctly from a parse failure, so the model can retry
+    // with shorter arguments instead of moving on unaware.
+    const OPENER = '```tool_call';
+    const openerIdx = text.lastIndexOf(OPENER);
+    if (openerIdx !== -1 && openerIdx >= lastMatchEnd) {
+      const body = text.slice(openerIdx + OPENER.length).replace(/^[ \t]*\n/, '');
+      onMalformed?.(
+        body.trim(),
+        'tool_call fence was truncated (no closing ``` found) — re-issue with shorter arguments',
+      );
     }
   }
   return calls;


### PR DESCRIPTION
## Summary

Fixes four independently-reproducible bugs filed against the org-runtime (`packages/@monomind/cli/src/orgrt/`) after real production runs. #204 (rewriting 6 buffered subprocess runners to a streaming model) is explicitly deferred to its own follow-up per its own "not urgent" framing.

Closes #202, #203, #205, #206.

- **#202** — `parseToolCalls` never detected a `` ```tool_call `` fence truncated before its closing `` ``` `` (model hit its per-response output limit mid-argument). The tool silently never executed and the model believed it had. Now flags the trailing unterminated opener via the existing `onMalformed` callback — all 11 fence-protocol runners already route that into feedback, so no runner-level changes needed.

- **#203** — a session that crashed after its mailbox message was already `shift()`ed for the SDK stream's yield lost that message forever: the replacement session's `stream()` found an empty queue and parked, looping on the 4-minute silent-stream watchdog until the circuit breaker closed its mailbox. `Mailbox` now tracks the shifted-but-unconfirmed message (`inFlight`); the crash-retry catch block in `daemon.ts` calls the new `reclaimInFlight()` right alongside the existing `detach()` call to put it back on the queue for the retry.

- **#205** — a mailbox closed on budget exhaustion produced the identical "boss is unreachable" idle-watchdog message as a genuine crash. `Mailbox.close()` now takes an optional reason (round-tripped through `serialize()`/`deserialize()` for checkpoint fidelity); the idle watchdog reports a distinct, actionable message naming the real cause (token/USD budget) and remedy.

- **#206** — `org run` exited 0 unconditionally once the run stopped, so no script/supervisor could tell success from failure. Also fixes a real gap found while implementing this: `scheduleBossRestart`'s give-up branch never called `stopOrg`, leaving the org dangling in `daemon.orgs` forever with a dead boss mailbox — without that fix the exit code would never even be reached in that case. `stopOrg`/`finishStop`/`persistState` now thread an optional `closedBy` reason (mirroring the existing `closedBy: 'crash-handler'` on the process-crash path); only the `org_complete` auto-stop path sets `closedBy: 'org-complete'`. `runAction` re-reads `runtime.json` after the run ends and exits 0 only for that clean completion or an explicit manual `org stop`; everything else exits 1.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Targeted `vitest` run across all touched files plus their existing neighbors — 135/135 passing (75/75 re-verified after rebuilding this branch, see note below)
- [x] Full `@monomind/cli` package suite — 2209 passing, exactly one unrelated pre-existing failure (`hooks_pretrain` NUL-byte timeout in `hooks-routing.ts`, confirmed to reproduce identically with these changes stashed out)
- [x] New tests added: `parseToolCalls` truncation detection, `Mailbox.reclaimInFlight`/`closeReason`, daemon-level idle-watchdog budget-message test, `scheduleBossRestart` exhausted-retries stop test, extracted+unit-tested `runOutcomeResult` exit-code decision

Note: supersedes #207, which was opened from a branch that had accidentally picked up unrelated unpushed local commits from another worktree session sharing this repo's refs. This PR is the same single commit, cherry-picked cleanly onto current `main` — diff is exactly the 11 files listed above, nothing else.