### PR TITLE
fix(orgrt): make the #205 budget-resume remedy actually work

### DIFF
--- a/packages/@monomind/cli/__tests__/orgrt/checkpoint-recoverable-close.test.ts
+++ b/packages/@monomind/cli/__tests__/orgrt/checkpoint-recoverable-close.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Follow-up to #205: the idle watchdog tells an operator to "raise the
+ * role's budget_tokens ... and resume from checkpoint" for a budget-
+ * exhausted boss. That remedy only works if resume actually leaves the
+ * mailbox usable — mergeCheckpoint() used to unconditionally re-close a
+ * mailbox that was checkpointed as closed, with no way to ever reopen it,
+ * making the suggested remedy a silent no-op. mergeCheckpoint() must leave
+ * a recoverably-closed mailbox (token-budget / usd-budget) OPEN on resume,
+ * while still re-closing a mailbox that was closed for any other reason
+ * (crash, terminal stop) — resuming a genuinely dead role's mailbox should
+ * not spring back to life.
+ */
+import { describe, it, expect } from 'vitest';
+import { Mailbox } from '../../src/orgrt/mailbox.js';
+import { mergeCheckpoint, type OrgCheckpoint, type RoleCheckpoint } from '../../src/orgrt/checkpoint.js';
+import type { RunningOrg, AgentRuntime } from '../../src/orgrt/daemon.js';
+
+function stubOrg(mailbox: Mailbox): RunningOrg {
+  const runtime = {
+    mailbox,
+    policy: { usage: 0, addUsage: () => {} },
+    metrics: { costUsd: 0 },
+    lastMessageId: undefined,
+    status: 'running',
+    error: undefined,
+  } as unknown as AgentRuntime;
+  return { agents: new Map([['boss', runtime]]) } as unknown as RunningOrg;
+}
+
+function roleCheckpoint(overrides: Partial<RoleCheckpoint>): RoleCheckpoint {
+  return {
+    mailboxQueue: [],
+    mailboxClosed: true,
+    tokensUsed: 0,
+    costUsd: 0,
+    status: 'running',
+    ...overrides,
+  };
+}
+
+function checkpoint(roleState: RoleCheckpoint): OrgCheckpoint {
+  return {
+    version: 1,
+    status: 'stopped',
+    run: 'run-1',
+    pid: 1,
+    updated: new Date(0).toISOString(),
+    roleState: { boss: roleState },
+    pendingRoles: [],
+    abandonedRoles: [],
+    checksum: 'unused-in-this-test',
+  };
+}
+
+describe('mergeCheckpoint — recoverable vs. terminal mailbox close on resume', () => {
+  it('leaves the mailbox OPEN when checkpointed closed for token-budget', () => {
+    const mailbox = new Mailbox();
+    const org = stubOrg(mailbox);
+    mergeCheckpoint(org, checkpoint(roleCheckpoint({ mailboxCloseReason: 'token-budget' })));
+    expect(mailbox.isClosed).toBe(false);
+  });
+
+  it('leaves the mailbox OPEN when checkpointed closed for usd-budget', () => {
+    const mailbox = new Mailbox();
+    const org = stubOrg(mailbox);
+    mergeCheckpoint(org, checkpoint(roleCheckpoint({ mailboxCloseReason: 'usd-budget' })));
+    expect(mailbox.isClosed).toBe(false);
+  });
+
+  it('still re-closes the mailbox for a plain (reasonless) close — a genuine crash/terminal stop', () => {
+    const mailbox = new Mailbox();
+    const org = stubOrg(mailbox);
+    mergeCheckpoint(org, checkpoint(roleCheckpoint({ mailboxCloseReason: undefined })));
+    expect(mailbox.isClosed).toBe(true);
+  });
+
+  it('does not touch an already-closed mailbox (no double-close)', () => {
+    const mailbox = new Mailbox();
+    mailbox.close('some-other-reason');
+    const org = stubOrg(mailbox);
+    mergeCheckpoint(org, checkpoint(roleCheckpoint({ mailboxCloseReason: 'token-budget' })));
+    // Already closed before merge ran — merge's `!runtime.mailbox.isClosed`
+    // guard means it's untouched either way; still closed either way.
+    expect(mailbox.isClosed).toBe(true);
+  });
+
+  it('does not close the mailbox at all when the checkpoint says it was open', () => {
+    const mailbox = new Mailbox();
+    const org = stubOrg(mailbox);
+    mergeCheckpoint(org, checkpoint(roleCheckpoint({ mailboxClosed: false })));
+    expect(mailbox.isClosed).toBe(false);
+  });
+});

--- a/packages/@monomind/cli/src/orgrt/checkpoint.ts
+++ b/packages/@monomind/cli/src/orgrt/checkpoint.ts
@@ -3,6 +3,7 @@
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { randomBytes, createHash } from 'node:crypto';
 import type { AgentRuntime, RunningOrg } from './daemon.js';
+import { isRecoverableCloseReason } from './mailbox.js';
 
 /** Checkpoint state for a single agent role */
 export interface RoleCheckpoint {
@@ -10,6 +11,10 @@ export interface RoleCheckpoint {
   mailboxQueue: string[];
   /** Whether the mailbox was closed */
   mailboxClosed: boolean;
+  /** Why it was closed, if given a reason (e.g. 'token-budget') — see
+   *  isRecoverableCloseReason in mailbox.ts; resume checks this before
+   *  re-closing the restored mailbox. */
+  mailboxCloseReason?: string;
   /** Token usage counter from policy engine */
   tokensUsed: number;
   /** Cost tracking */
@@ -69,6 +74,7 @@ export function captureCheckpoint(
     roleState[roleId] = {
       mailboxQueue: runtime.mailbox.serialize().queue,
       mailboxClosed: runtime.mailbox.isClosed,
+      mailboxCloseReason: runtime.mailbox.closeReason,
       tokensUsed: runtime.policy.usage,
       costUsd: runtime.metrics.costUsd,
       lastMessageId: runtime.lastMessageId,
@@ -199,9 +205,18 @@ export function mergeCheckpoint(
       restoreMailboxQueue(runtime, roleState.mailboxQueue);
     }
 
-    // Restore mailbox closed state
-    if (roleState.mailboxClosed && !runtime.mailbox.isClosed) {
-      runtime.mailbox.close();
+    // Restore mailbox closed state — EXCEPT for a recoverable close
+    // (budget exhaustion): re-closing it here would mean the idle
+    // watchdog's "raise the budget and resume from checkpoint" remedy
+    // silently does nothing, since nothing in this codebase ever reopens a
+    // closed mailbox otherwise. Leave it open so the resumed session can
+    // actually receive its next message.
+    if (
+      roleState.mailboxClosed &&
+      !runtime.mailbox.isClosed &&
+      !isRecoverableCloseReason(roleState.mailboxCloseReason)
+    ) {
+      runtime.mailbox.close(roleState.mailboxCloseReason);
     }
 
     // Restore policy usage counters

--- a/packages/@monomind/cli/src/orgrt/daemon.ts
+++ b/packages/@monomind/cli/src/orgrt/daemon.ts
@@ -7,7 +7,7 @@ import { writeJsonFileAtomic } from '../utils/json-file.js';
 import { reapOrphanedSdkProcesses } from '../utils/resource-governor.js';
 import { OrgBus } from './bus.js';
 import { PolicyEngine } from './policy.js';
-import { Mailbox } from './mailbox.js';
+import { Mailbox, isRecoverableCloseReason } from './mailbox.js';
 import { runAgentSession } from './session.js';
 import { attachForwarder } from './forwarder.js';
 import { BrokerLease, normalizeCredential } from './broker.js';
@@ -809,8 +809,12 @@ export class OrgDaemon {
       if (roleCheckpoint?.mailboxQueue?.length) {
         restoreMailboxQueue({ mailbox } as any, roleCheckpoint.mailboxQueue);
       }
-      if (roleCheckpoint?.mailboxClosed) {
-        mailbox.close();
+      // A recoverable close (budget exhaustion) is left open on resume — see
+      // isRecoverableCloseReason's doc comment. Re-closing it here would
+      // make the idle watchdog's "raise the budget and resume" remedy a
+      // no-op, since nothing in this codebase ever reopens a closed mailbox.
+      if (roleCheckpoint?.mailboxClosed && !isRecoverableCloseReason(roleCheckpoint.mailboxCloseReason)) {
+        mailbox.close(roleCheckpoint.mailboxCloseReason);
       }
       const policy = new PolicyEngine(
         role.id,

--- a/packages/@monomind/cli/src/orgrt/mailbox.ts
+++ b/packages/@monomind/cli/src/orgrt/mailbox.ts
@@ -6,6 +6,19 @@ export interface OrgUserMessage {
   session_id: string;
 }
 
+/** close() reasons that mean "paused, not dead" — the underlying condition
+ *  (a budget cap) can be raised by an operator, unlike a crash/terminal
+ *  close. Resume paths (checkpoint.ts's mergeCheckpoint, daemon.ts's
+ *  resume-spawn) check this before re-closing a checkpointed mailbox: a
+ *  mailbox checkpointed with one of these reasons is left open on resume
+ *  instead of being re-closed, or the idle watchdog's "raise the budget and
+ *  resume from checkpoint" remedy would silently do nothing — nothing in
+ *  this codebase ever reopens a closed mailbox otherwise. */
+const BUDGET_CLOSE_REASONS = new Set(['token-budget', 'usd-budget']);
+export function isRecoverableCloseReason(reason: string | undefined): boolean {
+  return reason !== undefined && BUDGET_CLOSE_REASONS.has(reason);
+}
+
 /**
  * Async message queue feeding one persistent SDK session.
  * push() from the daemon (deliveries from other agents / the user);


### PR DESCRIPTION
## Summary

Follow-up from a code review of #208 (merged). #208's idle-watchdog fix tells operators to "raise the role's budget_tokens ... and resume from checkpoint" for a budget-exhausted boss — but that remedy didn't actually work.

Both places that restore a checkpointed mailbox — `checkpoint.ts`'s `mergeCheckpoint` and `daemon.ts`'s resume-spawn path — unconditionally re-close a mailbox that was checkpointed as closed, and nothing in the codebase ever reopens a closed mailbox otherwise. So raising the budget and resuming from checkpoint just recreated the same permanently-closed mailbox: `push()` silently no-ops forever, including the "org resumed from checkpoint" kickoff message.

## Fix

- `Mailbox.isRecoverableCloseReason()` (exported): true for `'token-budget'` / `'usd-budget'` — reasons where the underlying condition is operator-fixable, unlike a crash/terminal close.
- `RoleCheckpoint` now also captures `mailboxCloseReason` (alongside the existing `mailboxClosed`).
- Both resume paths (`mergeCheckpoint`, `daemon.ts`'s resume-spawn) now only re-close the restored mailbox when the checkpointed close reason isn't recoverable — a budget-exhausted boss's mailbox is left open on resume, while a genuinely crashed/terminally-stopped role's mailbox still stays closed (no unintended resurrection).

## Test plan
- [x] `tsc --noEmit` clean
- [x] New unit test (`checkpoint-recoverable-close.test.ts`) covering: token-budget and usd-budget reasons left open; a plain/reasonless close still re-closed; an already-closed mailbox untouched; a checkpoint recording an open mailbox stays open
- [x] Existing `checkpoint-resume.test.ts`, `mailbox.test.ts`, `daemon.test.ts`, `scrollback.test.ts`, `feature-integration.test.ts` — 104/104 passing, no regressions