### PR TITLE
fix(orgrt): Mailbox.close() first-write-wins

### DIFF
--- a/packages/@monomind/cli/__tests__/orgrt/mailbox.test.ts
+++ b/packages/@monomind/cli/__tests__/orgrt/mailbox.test.ts
@@ -185,4 +185,31 @@ describe('closeReason (#205: budget-exhausted boss vs. genuinely unreachable)', 
     mb.deserialize({ queue: [], closed: true, consumedReal: 0 });
     expect(mb.closeReason).toBeUndefined();
   });
+
+  it('first write wins: a second close() call does not overwrite the first reason', () => {
+    // Mirrors session.ts's result-message handler, where a circuit-breaker
+    // trip (close(), no reason) and a budget check (close('token-budget'))
+    // are independent sibling `if`s that can both fire for one message —
+    // without first-write-wins, the terminal circuit-breaker close would
+    // silently get misclassified as a recoverable budget close, and the
+    // resume path would reopen a role meant to require manual intervention.
+    const mb = new Mailbox();
+    mb.close(); // e.g. circuit-breaker trip — genuinely terminal
+    mb.close('token-budget'); // e.g. a sibling budget check firing after
+    expect(mb.closeReason).toBeUndefined();
+  });
+
+  it('first write wins: a recoverable reason is not overwritten by a later plain close()', () => {
+    const mb = new Mailbox();
+    mb.close('usd-budget');
+    mb.close();
+    expect(mb.closeReason).toBe('usd-budget');
+  });
+
+  it('first write wins: two conflicting recoverable reasons keep the first', () => {
+    const mb = new Mailbox();
+    mb.close('token-budget');
+    mb.close('usd-budget');
+    expect(mb.closeReason).toBe('token-budget');
+  });
 });

--- a/packages/@monomind/cli/src/orgrt/checkpoint.ts
+++ b/packages/@monomind/cli/src/orgrt/checkpoint.ts
@@ -188,6 +188,13 @@ export function restoreMailboxQueue(runtime: AgentRuntime, queue: string[]): voi
 /**
  * Merge checkpoint state into running org
  * Used for resume operations to restore previous state
+ *
+ * NOT currently called from production code — daemon.ts's spawnRole builds
+ * each role's mailbox inline (its own roleCheckpoint-driven restore logic,
+ * duplicating the mailboxClosed/mailboxCloseReason handling below) rather
+ * than calling this. Exercised today only by tests. If you change the
+ * recoverable-close handling here, change it in daemon.ts's spawnRole too —
+ * see isRecoverableCloseReason's doc comment in mailbox.ts.
  */
 export function mergeCheckpoint(
   org: RunningOrg,

--- a/packages/@monomind/cli/src/orgrt/mailbox.ts
+++ b/packages/@monomind/cli/src/orgrt/mailbox.ts
@@ -8,12 +8,15 @@ export interface OrgUserMessage {
 
 /** close() reasons that mean "paused, not dead" — the underlying condition
  *  (a budget cap) can be raised by an operator, unlike a crash/terminal
- *  close. Resume paths (checkpoint.ts's mergeCheckpoint, daemon.ts's
- *  resume-spawn) check this before re-closing a checkpointed mailbox: a
- *  mailbox checkpointed with one of these reasons is left open on resume
- *  instead of being re-closed, or the idle watchdog's "raise the budget and
- *  resume from checkpoint" remedy would silently do nothing — nothing in
- *  this codebase ever reopens a closed mailbox otherwise. */
+ *  close. Checked before re-closing a checkpointed mailbox on resume: a
+ *  mailbox checkpointed with one of these reasons is left open instead of
+ *  being re-closed, or the idle watchdog's "raise the budget and resume
+ *  from checkpoint" remedy would silently do nothing — nothing in this
+ *  codebase ever reopens a closed mailbox otherwise. The only production
+ *  resume path is daemon.ts's inline spawnRole logic (where `new Mailbox()`
+ *  is constructed for a role with a roleCheckpoint); checkpoint.ts's
+ *  mergeCheckpoint() applies the same check but isn't currently called
+ *  outside tests — keep both in sync if either changes. */
 const BUDGET_CLOSE_REASONS = new Set(['token-budget', 'usd-budget']);
 export function isRecoverableCloseReason(reason: string | undefined): boolean {
   return reason !== undefined && BUDGET_CLOSE_REASONS.has(reason);
@@ -62,6 +65,15 @@ export class Mailbox {
   }
 
   close(reason?: string): void {
+    // First write wins. session.ts's result-message handler can call
+    // close() up to three times for one message (circuit-breaker trip,
+    // token-budget, USD-budget are independent sibling `if`s, not
+    // mutually exclusive) — without this guard the LAST call's reason
+    // silently overwrites the first, so a genuinely terminal
+    // circuit-breaker close could get misclassified as a recoverable
+    // budget close and the resume path would reopen a role that's
+    // supposed to require manual intervention.
+    if (this.closed) return;
     this.closed = true;
     this.closeReasonValue = reason;
     this.wake?.(); this.wake = null;


### PR DESCRIPTION
## Summary

Second-round review of #209 found a real gap in the same subsystem: `Mailbox.close()` had no guard against being called more than once, so the LAST call's reason silently won.

`session.ts`'s result-message handler can call `close()` up to three times for one message — circuit-breaker trip (`close()`, no reason), token-budget, and USD-budget checks are independent sibling `if`s, not mutually exclusive:

```ts
if (m.subtype && m.subtype !== 'success') {
  if (opts.circuitBreaker && ...) { ...; mailbox.close(); }
}
if (policy.overBudget) { ...; mailbox.close('token-budget'); }
if (policy.overBudgetUsd) { ...; mailbox.close('usd-budget'); }
```

A message that both trips the circuit breaker (genuinely terminal, needs manual intervention) *and* pushes the role past budget would end up with `closeReason` `'token-budget'` or `'usd-budget'` — whichever check ran last — and #209's `isRecoverableCloseReason` would then tell the resume path to silently reopen a role that was supposed to stay closed for a human to look at.

## Fix

Added a first-write-wins guard to `close()`, matching `push()`'s existing `if (this.closed) return` idiom.

Also documented (without changing behavior) a second, lower-severity finding from the same review: `mergeCheckpoint()` applies the same recoverable-close check but isn't called anywhere in production — `daemon.ts`'s `spawnRole` duplicates the same logic inline instead. Left both in place (unifying them was out of scope for this pass) but added explicit doc comments on both sides so a future change to one isn't made without the other, and so `isRecoverableCloseReason`'s doc comment doesn't overstate `mergeCheckpoint` as a live path.

## Test plan
- [x] `tsc --noEmit` clean
- [x] New regression tests: two conflicting `close()` calls in either order keep the first reason
- [x] `mailbox`, `checkpoint-recoverable-close`, `checkpoint-resume`, `daemon`, `session`, `scrollback`, `feature-integration`, `org-usd-budget-enforcement` suites — 124/124 passing