### PR TITLE
fix(orgrt): org run persists real crash state on an uncaught error

### DIFF
--- a/packages/@monomind/cli/__tests__/orgrt/persist-crash-state.test.ts
+++ b/packages/@monomind/cli/__tests__/orgrt/persist-crash-state.test.ts
@@ -1,0 +1,56 @@
+/**
+ * #206 follow-up (round 3 review): persistCrashStateAll() never captured
+ * WHY a run crashed — runOutcomeResult's "crashed: <error>" message
+ * (org.ts) always read "crashed: unknown error" regardless of the actual
+ * cause, since nothing ever populated runtime.json's `error` field on the
+ * crash-handler path. persistCrashStateAll now accepts an optional error
+ * string and writes it when given.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { OrgDaemon } from '../../src/orgrt/daemon.js';
+
+function fixture(root: string, name: string): void {
+  mkdirSync(join(root, '.monomind/orgs'), { recursive: true });
+  writeFileSync(join(root, '.monomind/orgs', `${name}.json`), JSON.stringify({
+    name, goal: `goal of ${name}`,
+    roles: [{ id: 'boss', title: 'Boss', type: 'boss', reports_to: null }],
+  }));
+}
+
+const hangingQuery = () => (async function* () { await new Promise(() => {}); })();
+
+describe('persistCrashStateAll', () => {
+  it('writes the given error message into runtime.json', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'daemon-crash-'));
+    fixture(root, 'alpha');
+    const d = new OrgDaemon(root, { queryFn: hangingQuery as any, forward: false });
+    await d.startOrg('alpha');
+
+    d.persistCrashStateAll('uncaughtException: boom');
+
+    const rt = JSON.parse(readFileSync(join(root, '.monomind/orgs/alpha/runtime.json'), 'utf8'));
+    expect(rt.status).toBe('crashed');
+    expect(rt.closedBy).toBe('crash-handler');
+    expect(rt.error).toBe('uncaughtException: boom');
+
+    await d.stopOrg('alpha');
+  });
+
+  it('omits the error field when called with no argument (backward compatible)', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'daemon-crash-noerr-'));
+    fixture(root, 'alpha');
+    const d = new OrgDaemon(root, { queryFn: hangingQuery as any, forward: false });
+    await d.startOrg('alpha');
+
+    d.persistCrashStateAll();
+
+    const rt = JSON.parse(readFileSync(join(root, '.monomind/orgs/alpha/runtime.json'), 'utf8'));
+    expect(rt.status).toBe('crashed');
+    expect(rt.error).toBeUndefined();
+
+    await d.stopOrg('alpha');
+  });
+});

--- a/packages/@monomind/cli/src/commands/org.ts
+++ b/packages/@monomind/cli/src/commands/org.ts
@@ -298,6 +298,25 @@ const runAction = async (ctx: CommandContext): Promise<CommandResult> => {
   }
   log(output.info(`org ${name} running (${running.def.roles.length} agents, run ${running.run}) — Ctrl-C or "monomind org stop ${name}" to stop`));
 
+  // #206 follow-up: without this, an uncaught error in this process left
+  // runtime.json's status stuck at 'running' (finishStop never runs), and
+  // runOutcomeResult's status === 'crashed' branch — the one meant to
+  // surface *why* the run failed — could never actually fire for `org run`,
+  // since nothing here ever wrote 'crashed'. Mirrors serveAction's
+  // crashExit, but deliberately does NOT touch SIGINT/SIGTERM — those are
+  // already handled by the wait loop below as a graceful stop, and
+  // registering a second, competing handler here would race it.
+  process.on('uncaughtException', (err) => {
+    try { console.error('[org run] uncaughtException:', err); } catch { /* stderr gone */ }
+    daemon.persistCrashStateAll(`uncaughtException: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+  process.on('unhandledRejection', (err) => {
+    try { console.error('[org run] unhandledRejection:', err); } catch { /* stderr gone */ }
+    daemon.persistCrashStateAll(`unhandledRejection: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
+
   // P1-12: Print the dashboard URL so CLI users know where to look.
   // The dashboard is normally spawned by a Claude Code SessionStart hook
   // (.claude/helpers/control-start.cjs) — but `org run` doesn't require
@@ -812,7 +831,7 @@ const serveAction = async (ctx: CommandContext): Promise<CommandResult> => {
   // shows what happened instead of a silent "pid is gone".
   const crashExit = (label: string, err: unknown): void => {
     try { console.error(`[org serve] ${label}:`, err); } catch { /* stderr gone */ }
-    daemon.persistCrashStateAll();
+    daemon.persistCrashStateAll(`${label}: ${err instanceof Error ? err.message : String(err)}`);
     daemon.clearHeartbeat();
     process.exitCode = 1;
   };

--- a/packages/@monomind/cli/src/orgrt/daemon.ts
+++ b/packages/@monomind/cli/src/orgrt/daemon.ts
@@ -1660,8 +1660,11 @@ export class OrgDaemon {
   }
 
   /** Mark every currently-running org as crashed in runtime.json.
-   *  Called from process-level crash handlers — must be synchronous and best-effort. */
-  persistCrashStateAll(): void {
+   *  Called from process-level crash handlers — must be synchronous and best-effort.
+   *  @param error the uncaught error/rejection reason, if known — without
+   *  this, `runOutcomeResult` (org.ts)'s "crashed: <error>" message always
+   *  read "crashed: unknown error" regardless of what actually happened. */
+  persistCrashStateAll(error?: string): void {
     for (const [name, org] of this.orgs) {
       try {
         const p = join(this.root, ORG_DIR, name, 'runtime.json');
@@ -1673,6 +1676,7 @@ export class OrgDaemon {
           pid: process.pid,
           updated: new Date().toISOString(),
           closedBy: 'crash-handler',
+          ...(error ? { error } : {}),
         });
       } catch {
         /* best effort — filesystem may be unavailable */


### PR DESCRIPTION
## Summary

Third-round review of #206 found that \`runOutcomeResult\`'s \`status === 'crashed'\` branch was unreachable from \`org run\`: \`persistCrashStateAll()\` (the only writer of \`status: 'crashed'\`) was wired up exclusively in \`org serve\`'s crash handlers, never in \`runAction\`. \`finishStop\` always writes \`'stopped'\` regardless of cause, so an uncaught exception in \`org run\` left \`runtime.json\` stuck at \`'running'\`, and the "crashed: \<error\>" message could never fire for the command it was actually added to — every real failure fell through to the generic "stopped without completing" branch instead. #206's actual contract (non-zero exit on any non-clean stop) was still correct either way; just the more specific, more actionable message was dead code.

Also fixed a second, smaller gap in the same function: even in \`org serve\` — the one place \`status: 'crashed'\` *was* reachable — \`persistCrashStateAll()\` never captured the actual error, so the message would always read "crashed: unknown error" regardless of what happened.

## Fix

- \`persistCrashStateAll()\` now accepts an optional error string and writes it into \`runtime.json\` when given.
- \`runAction\` (\`org run\`) registers \`uncaughtException\`/\`unhandledRejection\` handlers mirroring \`serveAction\`'s existing \`crashExit\`, persisting the real error before exiting 1. Deliberately does **not** touch \`SIGINT\`/\`SIGTERM\` — the wait loop already handles those as a graceful stop; a second, competing handler there would race it.
- \`serveAction\`'s existing \`crashExit\` now also passes the real error through instead of leaving it unpopulated.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] New \`persistCrashStateAll\` test (writes the given error; omits it when not given, for backward compatibility)
- [x] Targeted runs across \`org-run-outcome\`, \`daemon\`, \`org-command\`, \`org-runfile-poll\`, \`tool-fence\`, \`mailbox\`, \`checkpoint-recoverable-close\`, \`checkpoint-resume\`, \`session\` — 131/131 passing