### PR TITLE
[DO NOT MERGE] debug: instrument CI-only KG/FTS5 test failures

### DIFF
--- a/packages/@monomind/cli/src/memory/memory-bridge.ts
+++ b/packages/@monomind/cli/src/memory/memory-bridge.ts
@@ -1107,6 +1107,19 @@ export async function bridgeSearchEntries(options: {
           }
         }
 
+        if (/Quixotic|xyzzy-plugh|^routes$/.test(queryStr)) {
+          console.error(
+            `[DEBUG-CI-INVESTIGATION] query=${JSON.stringify(queryStr)} fts5Available=${typeof backend.keywordSearch === 'function'} fts5ResultCount=${fts5Results?.length ?? 'n/a'} preFilterHitCount=${keywordHits.length}`,
+          );
+          for (const h of keywordHits) {
+            const haystack = `${h.key || ''} ${h.content || ''}`.toLowerCase();
+            const matched = tokens.filter((t) => haystack.includes(t));
+            console.error(
+              `[DEBUG-CI-INVESTIGATION] candidate key=${JSON.stringify(h.key)} content=${JSON.stringify((h.content || '').slice(0, 200))} score=${h.score} provenance=${h.provenance} matchedTokens=${JSON.stringify(matched)} matchedFraction=${matched.length / tokens.length}`,
+            );
+          }
+        }
+
         // Issue #223/#224 follow-up: FTS5/BM25 ranks above are normalised
         // RELATIVE to the best result in this call's own small candidate set
         // (score = |rank| / maxRank), so the top — or sole — hit always

--- a/packages/@monomind/cli/src/memory/memory-bridge.ts
+++ b/packages/@monomind/cli/src/memory/memory-bridge.ts
@@ -463,6 +463,11 @@ async function loadEmbedder(): Promise<void> {
 
 async function getBackend(dbPath?: string): Promise<any | null> {
   const dir = getDbPath(dbPath);
+  if (dbPath && /\.tmp-(kg-eval|fts-sync)-/.test(dbPath)) {
+    console.error(
+      `[DEBUG-CI-INVESTIGATION] getBackend dbPath=${JSON.stringify(dbPath)} resolvedDir=${JSON.stringify(dir)} projectRoot=${JSON.stringify(getProjectRoot())} cwd=${JSON.stringify(process.cwd())} slotCount=${backendSlots.size} slotKeys=${JSON.stringify([...backendSlots.keys()])}`,
+    );
+  }
   let slot = backendSlots.get(dir);
   if (!slot) {
     if (backendSlots.size >= MAX_BACKEND_SLOTS) {
@@ -1109,7 +1114,7 @@ export async function bridgeSearchEntries(options: {
 
         if (/Quixotic|xyzzy-plugh|^routes$/.test(queryStr)) {
           console.error(
-            `[DEBUG-CI-INVESTIGATION] query=${JSON.stringify(queryStr)} fts5Available=${typeof backend.keywordSearch === 'function'} fts5ResultCount=${fts5Results?.length ?? 'n/a'} preFilterHitCount=${keywordHits.length}`,
+            `[DEBUG-CI-INVESTIGATION] query=${JSON.stringify(queryStr)} dbPathOption=${JSON.stringify(options.dbPath)} resolvedDir=${JSON.stringify(getDbPath(options.dbPath))} projectRoot=${JSON.stringify(getProjectRoot())} cwd=${JSON.stringify(process.cwd())} fts5Available=${typeof backend.keywordSearch === 'function'} fts5ResultCount=${fts5Results?.length ?? 'n/a'} preFilterHitCount=${keywordHits.length}`,
           );
           for (const h of keywordHits) {
             const haystack = `${h.key || ''} ${h.content || ''}`.toLowerCase();

--- a/packages/@monomind/memory/src/sql-backend.ts
+++ b/packages/@monomind/memory/src/sql-backend.ts
@@ -288,6 +288,7 @@ export class SqlBackend extends EventEmitter implements IMemoryBackend {
 
     this.migrationReport = initializeSchema(this.driver);
     this._fts5Available = hasFTS5Table(this.driver);
+    console.error(`[DEBUG-CI-INVESTIGATION] fts5Available=${this._fts5Available} platform=${process.platform} arch=${process.arch} nodeVersion=${process.version}`);
     if (this.config.verbose && this.migrationReport.legacyColumnFound) {
       console.log(
         `[SqlBackend] migrated ${this.migrationReport.migrated} inline embedding(s); ` +
@@ -502,6 +503,19 @@ export class SqlBackend extends EventEmitter implements IMemoryBackend {
         entry.lastAccessedAt,
       ] as SqlParam[],
     );
+
+    if (entry.key === 'upsert-target' || entry.key === 'marker') {
+      try {
+        const ftsRows = d.all('SELECT rowid, entry_id, key, content FROM memory_entries_fts WHERE entry_id = ?', [
+          entry.id,
+        ]);
+        console.error(
+          `[DEBUG-CI-INVESTIGATION] after store key=${entry.key} entry.id=${entry.id} ftsRowCount=${ftsRows.length} ftsRows=${JSON.stringify(ftsRows)}`,
+        );
+      } catch (e) {
+        console.error('[DEBUG-CI-INVESTIGATION] fts row check failed:', e);
+      }
+    }
 
     d.run('DELETE FROM memory_entry_tags WHERE entry_id = ?', [entry.id]);
     for (const tag of entry.tags) {


### PR DESCRIPTION
Throwaway diagnostic PR to get real CI-side output for the 2 tests still failing after 2.10.13 (pushed to main):
- `src/__tests__/kg-eval-retrieval.test.ts` (K9 m1: false-positive triplets)
- `src/__tests__/memory-bridge-fts-sync.test.ts` (score 0.82 not >0.9; duplicate row on upsert)

Both pass locally (macOS/arm64) but fail deterministically on CI (Linux). Added `console.error` tracing to see the actual FTS5/keyword-search behavior CI produces. Will close without merging once the CI log is captured.