### PR TITLE
fix(agent-exec): allow fence-protocol tool calls by bare name

### DIFF
--- a/packages/@monomind/cli/src/__tests__/agent-exec.test.ts
+++ b/packages/@monomind/cli/src/__tests__/agent-exec.test.ts
@@ -263,6 +263,41 @@ describe('agent exec: canUseTool gate', () => {
     });
   });
 
+  // Regression for the antigravity/fence-protocol path: unlike the native
+  // SDK path above, fence-protocol runners (antigravity-runner.ts, and any
+  // other AgentRunner built on tool-fence.ts's executeToolCall) call
+  // canUseTool with the BARE tool name straight from the model's
+  // ```tool_call fence -- never mcp__org__-prefixed, since these tools were
+  // never registered as real SDK MCP tools to begin with. Before this fix,
+  // allowedToolNames only ever contained the prefixed form, so every
+  // fence-protocol tool call was denied with "was not in the tool list this
+  // exec call was given" regardless of --tools-file/--tool-names --
+  // antigravity chat turns silently fell back to the model's own native
+  // Bash/Write tools instead of ever reaching save_document et al., and the
+  // stdio bridge's tool_call/tool_result events (which drive the desktop
+  // app's tool-call UI) never fired since tool.handler was never reached.
+  it('also allows the bare (unprefixed) tool name, for fence-protocol runners that never register real MCP tools', async () => {
+    const h = makeHarness({ toolSpecs: [echoTool] });
+    let captured:
+      | ((toolName: string, input: Record<string, unknown>) => Promise<unknown>)
+      | undefined;
+    const runner: AgentRunner = {
+      async *run(a) {
+        captured = a.canUseTool;
+        yield { type: 'result', session_id: 's1', subtype: 'success' };
+      },
+    };
+    await run(h, runner);
+
+    expect(captured).toBeTypeOf('function');
+    await expect(captured!('create_nodes', {})).resolves.toMatchObject({
+      behavior: 'allow',
+    });
+    await expect(captured!('delete_everything', {})).resolves.toMatchObject({
+      behavior: 'deny',
+    });
+  });
+
   // Regression for the mono-agent Chat panel's "let it shell out to
   // monomind/monoagentcli directly" fallback (measured to be far more
   // reliable for the model to actually use than the mcp__org__* tool

--- a/packages/@monomind/cli/src/orgrt/agent-exec.ts
+++ b/packages/@monomind/cli/src/orgrt/agent-exec.ts
@@ -451,7 +451,21 @@ export async function runAgentExec(opts: AgentExecOptions): Promise<number> {
   // approving every tool in that already-scoped list is the correct
   // default, not a laxer one: this narrows the SDK's own default-deny-all
   // down to exactly what was asked for, nothing broader.
-  const allowedToolNames = new Set(tools.map((t) => `mcp__org__${t.name}`));
+  //
+  // Both name forms are included because this same canUseTool is shared by
+  // two different calling conventions: the native SDK path
+  // (ClaudeAgentRunner) registers these as real MCP tools and the SDK
+  // always prefixes the server name, so it calls canUseTool with
+  // "mcp__org__<name>"; fence-protocol runners (antigravity-runner.ts and
+  // any other AgentRunner built on tool-fence.ts's executeToolCall) never
+  // register real tools at all — the model calls them by emitting a
+  // ```tool_call fence, and executeToolCall passes canUseTool the bare name
+  // straight off that fence. Checking only the prefixed form denied every
+  // fence-protocol call outright ("was not in the tool list this exec call
+  // was given"), which silently broke tool use for those runtimes:
+  // tool.handler (the stdio bridge that actually emits tool_call/tool_result
+  // on the wire) was never reached, since canUseTool denies before it runs.
+  const allowedToolNames = new Set(tools.flatMap((t) => [`mcp__org__${t.name}`, t.name]));
   const bashPrefixes = opts.allowBashPrefixes ?? [];
   // A prefix match on its own only checks the FIRST token — the whole
   // string still runs through a real shell, so `monomind org list; rm -rf


### PR DESCRIPTION
## Summary
- `allowedToolNames` in `canUseTool` only ever contained the `mcp__org__`-prefixed form the native Claude SDK tool-registration path uses. Fence-protocol runners (`antigravity-runner.ts`, and any other `AgentRunner` built on `tool-fence.ts`'s `executeToolCall`) call `canUseTool` with the model's tool-call fence name **unprefixed**, so every one of their tool calls was silently denied.
- This broke tool use entirely for those runtimes: `tool.handler` (the stdio bridge that emits the `tool_call`/`tool_result` NDJSON frames a caller's UI relies on, e.g. mono-agent's desktop app) was never reached, since `canUseTool` denies before the handler runs.
- Fix: `allowedToolNames` now includes both the prefixed and bare form of each requested tool name — a strict superset of the previous allowlist, so the existing native-SDK-path behavior/tests are unaffected.

## Evidence
Reproduced against a real antigravity turn (`monoagentcli chat --runtime antigravity --tools monoagent ...` asking the model to call a mono-agent-supplied tool):
- **Before:** the model's own reply reported `Tool "save_document" was not in the tool list this exec call was given.` and fell back to writing the file directly via its native tools instead.
- **After** (built this branch, pointed the caller at it via `MONOMIND_BIN`): the turn round-trips a correct `tool_call` → `tool_result` pair (`{"type":"tool_call","id":"tc_1","name":"save_document","args":{...}}` / `{"type":"tool_result","id":"tc_1","ok":true,"result":{"text":"...\"vault_document_id\":\"doc-1475\"..."}}`).

## Test plan
- [x] New regression test: `agent exec: canUseTool gate > also allows the bare (unprefixed) tool name, for fence-protocol runners that never register real MCP tools` — confirmed RED (fails with `behavior: 'deny'`) before the fix, GREEN after.
- [x] Existing regression test for the prefixed-name path still passes unchanged.
- [x] Full `@monomind/cli` package suite: 2953/2955 passing (the 2 failures are a pre-existing, unrelated `chokidar` internal-API mismatch in `chokidar-persistent-watch-crash.test.ts` — confirmed identical failures on `main` before this change, via `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHMRQmj4cHe2KrGcBpd3iw